### PR TITLE
docs: add PROJECT documentation to all templates

### DIFF
--- a/2d-phaser-basic/PROJECT/Context.md
+++ b/2d-phaser-basic/PROJECT/Context.md
@@ -1,0 +1,24 @@
+# Context — 2d-phaser-basic
+
+## Project Overview
+
+Phaser 3 scaffold mounted inside a React shell. `GameComponent` boots a `Phaser.Game` into a DOM container and `MainScene` sets up a sky-blue viewport, an Arcade Physics world, and a single static green ground rectangle. The game uses full-window sizing with `Phaser.Scale.RESIZE`, and `Game.ts` patches Phaser's `setDisplaySize` / `setScale` / Tween scale behavior so that sprite scaling stays consistent with the declared display size.
+
+## Tech Stack
+
+_Exact versions are in `package.json`._
+
+- **Game engine**: `phaser` (Arcade Physics)
+- **Shell**: React, `react-dom`
+- **Build / Lang**: Vite, TypeScript
+- **Styling**: Tailwind CSS
+- **Multiplayer (unwired)**: `@agent8/gameserver`
+- **Icons (unwired)**: `lucide-react`
+
+## Critical Memory
+
+- React owns only the mount point; all gameplay lives in Phaser under `src/game/`. Do not render game objects from React.
+- `GameComponent` creates the `Phaser.Game` once via a `useRef` guard and calls `destroy(true)` on unmount — preserve this lifecycle to avoid duplicate game instances under React StrictMode.
+- `Game.ts` contains a `CRITICAL` block that overrides `Sprite.prototype.setDisplaySize` / `setScale`, `Image.prototype.setDisplaySize` / `setScale`, and `TweenManager.prototype.add`. It is marked LLM-modification-prohibited; sprite sizing/tweens depend on it.
+- Assets are declared in `src/assets.json` (`sprites` map) and currently empty — load textures in `MainScene.preload()` by reading this manifest.
+- Canvas uses `Phaser.Scale.RESIZE`; read `this.cameras.main.width/height` or `this.sys.game.canvas.width/height` instead of hard-coding dimensions.

--- a/2d-phaser-basic/PROJECT/Requirements.md
+++ b/2d-phaser-basic/PROJECT/Requirements.md
@@ -1,0 +1,19 @@
+# Requirements — 2d-phaser-basic
+
+## Coding Patterns
+
+- Keep the React/Phaser boundary clean: React mounts the container in `GameComponent`, Phaser owns everything under `src/game/`. Do not drive game state from React.
+- Add new scenes under `src/game/scenes/` and register them in the `scene: []` array inside `createGame` (`Game.ts`) — scene switching goes through `this.scene.start(key)`, not through React.
+- Declare all texture/audio URLs in `src/assets.json` and load them in the owning scene's `preload()`; do not hard-code URLs inside `create()` / `update()`.
+- Read canvas dimensions from `this.cameras.main` or `this.sys.game.canvas`; the game uses `Phaser.Scale.RESIZE`, so fixed pixel values drift.
+- Put physics bodies through Arcade Physics (`this.physics.add.existing(...)` / `this.physics.add.sprite(...)`); `gravity.y` defaults to `2000`.
+
+## Known Issues / Constraints
+
+- The `game.events.once('ready', …)` block in `Game.ts` monkey-patches `Phaser.GameObjects.Sprite` / `Image` `setDisplaySize` + `setScale` and `Phaser.Tweens.TweenManager.add` globally. It is explicitly marked LLM-modification-prohibited. Sprites that call `setDisplaySize` first will have subsequent `setScale` / scale tweens interpreted relative to that base size, not the texture size — account for this when tuning visuals.
+- `@agent8/gameserver` is in `dependencies` but unused; there is no networking, session, or room code.
+- `lucide-react` is installed but nothing imports it.
+- `tailwindcss` is configured but the only React surface is a full-viewport container, so utility classes have no target until UI is added.
+- `assets.json` ships empty (`{"sprites": {}}`); `MainScene.preload()` is a no-op until entries are added.
+- `MainScene.cursors` is declared but never assigned — input bindings (e.g. `this.input.keyboard.createCursorKeys()`) still need to be wired.
+- `index.html` posts `GAME_SIZE_RESPONSE` to `window.parent` for embed hosts; if you change the mount size, the reported dimensions follow the document, not the Phaser canvas.

--- a/2d-phaser-basic/PROJECT/Status.md
+++ b/2d-phaser-basic/PROJECT/Status.md
@@ -1,0 +1,20 @@
+# Status — 2d-phaser-basic
+
+## Implemented
+
+- React 18 shell (`main.tsx` → `App.tsx` → `GameComponent`) mounting a full-viewport Phaser canvas
+- `Phaser.Game` lifecycle with `StrictMode`-safe single-instance guard and `destroy(true)` cleanup
+- `createGame` config: Arcade Physics (`gravity.y: 2000`), `Phaser.Scale.RESIZE`, `autoCenter: CENTER_BOTH`, single `MainScene`
+- Global sprite/tween scaling patch in `Game.ts` (`setDisplaySize` / `setScale` / `TweenManager.add` override, keyed to `baseDisplayWidth`/`baseDisplayHeight`)
+- `MainScene`: sky-blue background, physics world bounds matching canvas, static green ground rectangle with Arcade body
+- `assets.json` manifest scaffold consumed by `MainScene`
+- Embed-host size reporting via `postMessage` in `index.html`
+
+## Installed but not wired
+
+- `@agent8/gameserver` — no networking / session code
+- `lucide-react` — no imports
+- `tailwindcss` — directives loaded via `index.css`, no utility usage in markup
+- `MainScene.cursors` field — declared but never initialized; no input handling
+- `MainScene.preload()` / `update()` — empty bodies
+- `assets.json.sprites` — empty map, no textures loaded

--- a/2d-phaser-basic/PROJECT/Structure.md
+++ b/2d-phaser-basic/PROJECT/Structure.md
@@ -1,45 +1,44 @@
-# [PROJECT TITLE]
+# Structure — 2d-phaser-basic
 
-## Project Summary
+## `src/main.tsx`
 
-[THIS IS TEMPLATE PROJECT, PLEASE UPDATE HERE]
+Entry point. Mounts `<App />` into `#root` with React 18 `createRoot` under `StrictMode`. Imports `index.css`.
 
-This project is a template project with a basic 2D. It is implemented using Phaser. It can be used to implement games like boardgame or simple 2d game.
+## `src/App.tsx`
 
-## Implementation Strategy
+Root component. Wraps `<GameComponent />` in a full-viewport `.app` container.
 
-- [THIS IS TEMPLATE PROJECT, PLEASE UPDATE HERE]
+## `src/App.css`, `src/index.css`
 
-## Implemented Features
+Component/global styles. `App.css` pins `html`/`body`/`.app` to `100vw` / `100vh` with `overflow: hidden`. `index.css` holds the Tailwind directives.
 
-- [THIS IS TEMPLATE PROJECT, PLEASE UPDATE HERE]
+## `src/assets.json`
 
-## File Structure Overview
+Asset manifest (`{ "sprites": {} }`). Consumed by `MainScene` — populate entries here and load them in `preload()`.
 
-### src/main.tsx
+## `src/components/GameComponent.tsx`
 
-- Entry point for the application
-- Sets up React rendering with React 18's createRoot API
-- Imports and applies global CSS
+React host for Phaser. Renders a `#phaser-game` div (100% × 100vh), calls `createGame(containerId)` in a `useEffect` guarded by a ref, and tears the game down with `game.destroy(true)` on unmount.
 
-### src/App.tsx
+## `src/game/Game.ts`
 
-- Root component of the application
-- Responsible for loading the GameComponent.
+Exports `createGame(parent)`. Builds the `Phaser.Types.Core.GameConfig`:
 
-### src/components/GameComponent.tsx
+- `type: Phaser.AUTO`, full-window `width`/`height`, `parent` set to the React container id
+- `physics.default: 'arcade'` with `gravity.y: 2000` and `debug: false`
+- `scene: [MainScene]`
+- `scale.mode: Phaser.Scale.RESIZE`, `autoCenter: Phaser.Scale.CENTER_BOTH`
 
-- Sets up the container to start Phaser in HTML and calls createGame from src/game/Game.ts.
+Also installs a `game.events.once('ready', …)` patch that overrides `Sprite`/`Image` `setDisplaySize` + `setScale` and `TweenManager.add` so `scale`/`scaleX`/`scaleY` operate relative to a stored `baseDisplayWidth` / `baseDisplayHeight`. Marked `CRITICAL — LLM/AI MODIFICATION PROHIBITED`.
 
-### src/game/Game.ts
+## `src/game/scenes/MainScene.ts`
 
-- Provides the createGame function, which executes `new Phaser.Game(config)` with Phaser settings.
+Sole scene (`key: 'MainScene'`). In `create()` it sets physics world bounds to the canvas size, paints a `#87CEEB` (sky blue) background, and adds a `60px` tall green (`0x00ff00`) rectangle across the bottom with a static Arcade body. `preload()` and `update()` are empty. Declares private `cursors` and `ground` fields; `cursors` is unused until input wiring is added.
 
-### src/game/scenes/MainScene.ts
+## `index.html`
 
-- Manages the main scene of the game.
+Vite HTML shell. Serves `/src/main.tsx`, renders an inline `Loading` spinner inside `#root` for pre-mount, and posts `GAME_SIZE_RESPONSE` messages to `window.parent` on `load` / `resize` / `REQUEST_GAME_SIZE` for embedding hosts.
 
-### src/App.css
+## `vite.config.ts`, `tsconfig*.json`, `tailwind.config.js`, `postcss.config.js`
 
-- Contains component-specific styles for the App component
-- Demonstrates how to use component-scoped CSS
+Standard Vite + React + TypeScript + Tailwind toolchain configuration.

--- a/2d-phaser-sprite-character-gravity/PROJECT/Context.md
+++ b/2d-phaser-sprite-character-gravity/PROJECT/Context.md
@@ -1,0 +1,24 @@
+# Context — 2d-phaser-sprite-character-gravity
+
+## Project Overview
+
+Phaser 3 scaffold running inside a React shell. A single `MainScene` boots Arcade Physics with downward gravity, spawns a static ground rectangle, and places a gravity-bound `SpriteCharacter` (extends `Phaser.Physics.Arcade.Sprite`) that handles left/right movement, ground-checked jump, and a timed melee attack with a transient hitbox. Sprite sheet is loaded from a URL declared in `src/assets.json`.
+
+## Tech Stack
+
+_Exact versions are in `package.json`._
+
+- **Game engine**: Phaser 3 (Arcade Physics)
+- **Shell**: React, ReactDOM
+- **Icons**: `lucide-react`
+- **Multiplayer (unwired)**: `@agent8/gameserver`
+- **Build / Lang**: Vite, TypeScript
+- **Styling**: Tailwind CSS
+
+## Critical Memory
+
+- The game runs entirely inside Phaser. React only mounts a `<div id="phaser-game">` and calls `createGame` once per mount; `gameInstanceRef` guards against double-init and disposes via `destroy(true)` on unmount.
+- `src/game/Game.ts` contains a `// CRITICAL: DO NOT MODIFY` block that monkey-patches `Phaser.GameObjects.Sprite/Image` `setDisplaySize` / `setScale` and `Phaser.Tweens.TweenManager.add`. Scale values are reinterpreted against a cached `baseDisplayWidth/Height` — do not remove or edit this block.
+- Arcade gravity is `{ x: 0, y: 2000 }`. Jumps are gated by `body.touching.down || body.blocked.down`; any new platform must be an Arcade static/dynamic body added via `physics.add.collider`.
+- Sprite sheet URL, `frameWidth`, and `frameHeight` come from `src/assets.json` under `sprites["2dbasic"]`. Animation frame ranges in `SpriteCharacter` are tied to that specific sheet layout.
+- Canvas uses `Phaser.Scale.RESIZE` at `window.innerWidth/innerHeight`; world bounds are set once in `create()` and do not auto-update on window resize.

--- a/2d-phaser-sprite-character-gravity/PROJECT/Requirements.md
+++ b/2d-phaser-sprite-character-gravity/PROJECT/Requirements.md
@@ -1,0 +1,20 @@
+# Requirements — 2d-phaser-sprite-character-gravity
+
+## Coding Patterns
+
+- All gameplay code lives under `src/game/`; React under `src/components/` is a thin host and must not reach into Phaser objects directly.
+- Extend behavior by subclassing `Phaser.Physics.Arcade.Sprite` (same pattern as `SpriteCharacter`) or by adding new scenes under `src/game/scenes/`, not by inlining logic into `GameComponent.tsx`.
+- Load sprite/audio URLs and frame metadata through `src/assets.json` and read them in `preload()`; do not hardcode asset URLs inside scenes or characters.
+- Animation keys are namespaced by texture key (`` `${spriteKey}-left` ``, etc.) and guarded by `anims.exists(...)` — reuse that convention so multiple instances of the same sheet don't re-register animations.
+- Ground checks go through `body.touching.down || body.blocked.down`. New platforms must register with `this.physics.add.collider(player, platform)`.
+- The critical section in `Game.ts` (Sprite/Image scale + Tween overrides) is off-limits; build scaling logic on top of `setDisplaySize` + `setScale`, not by editing the patch.
+
+## Known Issues / Constraints
+
+- Arcade Physics only — no tilemap, no Matter, no Rapier. `gravity.y` is hardcoded to `2000` in `Game.ts`.
+- `physics.world.createDebugGraphic()` is called in `preload()`, so the physics debug overlay is always on. Remove it for production.
+- World bounds are set once in `create()` from the initial canvas size; `Phaser.Scale.RESIZE` will grow the canvas but physics bounds stay fixed.
+- `SpriteCharacter` is tied to the `2dbasic` sheet layout: frames `0` (idle), `3` (jump), `4–7` (left), `8–11` (right), `12–15` (attack). A different sheet needs matching ranges.
+- Attack hitbox is a plain `Phaser.GameObjects.Rectangle` with Arcade physics added; no overlap handler is wired — damage logic is the caller's responsibility.
+- `attackSound` is declared but never loaded or assigned; the `try/catch` around `.play()` is dead code until audio is added to `assets.json`.
+- `console.log("Jumping!")` fires every successful jump — strip before shipping.

--- a/2d-phaser-sprite-character-gravity/PROJECT/Status.md
+++ b/2d-phaser-sprite-character-gravity/PROJECT/Status.md
@@ -1,0 +1,20 @@
+# Status — 2d-phaser-sprite-character-gravity
+
+## Implemented
+
+- React shell mounts Phaser via `GameComponent` with StrictMode-safe single-init and teardown on unmount
+- `Phaser.Game` config with Arcade Physics (`gravity.y = 2000`), `Scale.RESIZE`, full-window canvas
+- Critical scale/tween compatibility patch in `Game.ts` (`setDisplaySize`, `setScale`, `TweenManager.add`)
+- `MainScene` with sky-blue background, static ground rectangle, world bounds, physics debug graphic
+- `SpriteCharacter` (extends `Phaser.Physics.Arcade.Sprite`) with idle / left / right / jump / attack animations driven from the `2dbasic` sheet
+- Arrow-key movement, ground-checked jump, Space-key attack with transient hitbox and 300ms auto-destroy + 500ms safety timeout
+- Player ↔ ground collider, world-bounds collision, and `setBounce(0.2)`
+- Sprite sheet loaded from `src/assets.json` with `frameWidth`/`frameHeight` metadata
+
+## Installed but not wired
+
+- `@agent8/gameserver` — no networking / session code
+- `lucide-react` — no icons rendered anywhere
+- Tailwind CSS — directives included but no utility classes used in components
+- `attackSound` field on `SpriteCharacter` — declared but never loaded or assigned
+- Attack hitbox overlap/damage handler — hitbox is spawned but no `physics.add.overlap` target is registered

--- a/2d-phaser-sprite-character-gravity/PROJECT/Structure.md
+++ b/2d-phaser-sprite-character-gravity/PROJECT/Structure.md
@@ -1,51 +1,29 @@
-# [PROJECT TITLE]
+# Structure — 2d-phaser-sprite-character-gravity
 
-## Project Summary
+## `src/main.tsx`, `src/App.tsx`
 
-[THIS IS TEMPLATE PROJECT, PLEASE UPDATE HERE]
+Entry point and root component. `App` renders `GameComponent` inside a full-viewport `.app` container.
 
-This project is a template project with a basic 2D sprite character. It is implemented using Phaser, and the character has gravity and collision detection applied by default. It can be used to implement games like platformers where characters move on a flat view, stepping on obstacles.
+## `src/App.css`, `src/index.css`
 
-## Implementation Strategy
+Component styles and global base. `index.css` pulls in Tailwind directives; `App.css` locks `body/html` to no-scroll full-viewport.
 
-- [THIS IS TEMPLATE PROJECT, PLEASE UPDATE HERE]
+## `src/assets.json`
 
-## Implemented Features
+Asset manifest — sprite sheet URL and `frameWidth`/`frameHeight` metadata for the `2dbasic` character.
 
-- [THIS IS TEMPLATE PROJECT, PLEASE UPDATE HERE]
+## `src/components/GameComponent.tsx`
 
-## File Structure Overview
+React host for Phaser. Renders `<div id="phaser-game">`, calls `createGame(containerId)` once via `useEffect`, and destroys the game instance on unmount. Guarded by a `gameInstanceRef` so StrictMode double-invoke does not create two games.
 
-### src/main.tsx
+## `src/game/Game.ts`
 
-- Entry point for the application
-- Sets up React rendering with React 18's createRoot API
-- Imports and applies global CSS
+Exports `createGame(parent)`. Builds the `Phaser.Game` config: `Phaser.AUTO` renderer, full-window size, Arcade Physics with `gravity.y = 2000`, `Phaser.Scale.RESIZE` + `CENTER_BOTH`, and `MainScene` as the only scene. Contains a marked critical section that monkey-patches `Sprite/Image.setDisplaySize`, `setScale`, and `TweenManager.add` to preserve a base display size under scaling.
 
-### src/App.tsx
+## `src/game/scenes/MainScene.ts`
 
-- Root component of the application
-- Responsible for loading the GameComponent.
+Single scene. `preload()` loads the sprite sheet from `assets.json`. `create()` enables the physics debug graphic, sets world bounds to canvas size, paints a sky-blue background, builds a static green ground rectangle at the bottom, spawns one `SpriteCharacter`, registers a player–ground collider, and creates the cursor keys handler. `update()` forwards cursors to the character.
 
-### src/components/GameComponent.tsx
+## `src/game/characters/SpriteCharacter.ts`
 
-- Sets up the container to start Phaser in HTML and calls createGame from src/game/Game.ts.
-
-### src/game/Game.ts
-
-- Provides the createGame function, which executes `new Phaser.Game(config)` with Phaser settings.
-
-### src/game/scenes/MainScene.ts
-
-- Manages the main scene of the game.
-- Loads and controls the main character.
-
-### src/game/characters/SpriteCharacter.ts
-
-- Declares a reusable sprite character.
-- Implemented by extending `Phaser.Physics.Arcade.Sprite`.
-
-### src/App.css
-
-- Contains component-specific styles for the App component
-- Demonstrates how to use component-scoped CSS
+`Phaser.Physics.Arcade.Sprite` subclass. Registers five animations keyed by texture name (`-left`, `-right`, `-turn`, `-jump`, `-attack`) from fixed frame ranges of the `2dbasic` sheet. Handles `moveLeft` / `moveRight` / `stop` / `jump` (ground-checked) / `attack` (spawns a rectangular hitbox via `createAttackHitbox`, auto-destroys after 300ms, with a 500ms safety timer if `animationcomplete` never fires). `update(cursors)` maps Arrow keys to movement/jump and Space to attack, and ignores input while `isAttacking`.

--- a/basic-2d/PROJECT/Context.md
+++ b/basic-2d/PROJECT/Context.md
@@ -1,0 +1,20 @@
+# Context — basic-2d
+
+## Project Overview
+
+Minimal React + TypeScript + Vite scaffold for a 2D web app. Renders a single `App` component with a Tailwind-styled counter button — no game loop, no canvas, no rendering library. `@agent8/gameserver` and `lucide-react` are installed but unused.
+
+## Tech Stack
+
+_Exact versions are in `package.json`._
+
+- **Framework**: React, React DOM
+- **Build / Lang**: Vite, TypeScript
+- **Styling**: Tailwind CSS (via PostCSS + Autoprefixer)
+- **Icons (unused)**: `lucide-react`
+- **Multiplayer (unwired)**: `@agent8/gameserver`
+
+## Critical Memory
+
+- Asset manifest lives at `src/assets.json` (`{ "images": {} }`) — populate it when adding image assets.
+- `index.html` posts `GAME_SIZE_RESPONSE` messages to `window.parent` on load/resize; the host iframe depends on this handshake.

--- a/basic-2d/PROJECT/Requirements.md
+++ b/basic-2d/PROJECT/Requirements.md
@@ -1,0 +1,13 @@
+# Requirements — basic-2d
+
+## Coding Patterns
+
+- Style with Tailwind utility classes; reserve CSS files for layout primitives (`App.css` scopes `#root`).
+- Register image assets in `src/assets.json` rather than importing them ad-hoc.
+- Keep the `GAME_SIZE_RESPONSE` postMessage handshake in `index.html` intact when editing the shell.
+
+## Known Issues / Constraints
+
+- No 2D rendering library (Canvas / Phaser / PixiJS) is included — pick and wire one before building game logic.
+- `@agent8/gameserver` and `lucide-react` are installed but unused; tree-shaking handles them, but remove if not adopted.
+- `StrictMode` double-invokes effects in development — account for this when adding game loops or subscriptions.

--- a/basic-2d/PROJECT/Status.md
+++ b/basic-2d/PROJECT/Status.md
@@ -1,0 +1,15 @@
+# Status — basic-2d
+
+## Implemented
+
+- React + TypeScript + Vite build pipeline
+- Tailwind CSS styling pipeline (PostCSS + Autoprefixer)
+- Placeholder `App` with a `useState` counter button
+- Empty asset manifest (`src/assets.json`)
+- Parent-window size reporting via `postMessage` in `index.html`
+
+## Installed but not wired
+
+- `@agent8/gameserver` — no networking / session code
+- `lucide-react` — no icons used
+- No 2D rendering engine, game loop, state store, input handling, or scene system

--- a/basic-2d/PROJECT/Structure.md
+++ b/basic-2d/PROJECT/Structure.md
@@ -1,0 +1,40 @@
+# Structure — basic-2d
+
+## `index.html`
+
+Vite entry HTML. Includes an inline loading spinner shown before React mounts, and a `postMessage` bridge that reports document size to the parent window (`GAME_SIZE_RESPONSE`).
+
+## `src/main.tsx`
+
+React entry. Mounts `<App />` in `StrictMode` into `#root`.
+
+## `src/App.tsx`
+
+Root component. Renders a Tailwind-styled counter button using `useState`.
+
+## `src/App.css`
+
+Component styles for `#root` (centered layout, max-width).
+
+## `src/index.css`
+
+Global base — Tailwind directives only (`@tailwind base/components/utilities`).
+
+## `src/assets.json`
+
+Asset manifest. Empty `images` map by default.
+
+## `src/vite-env.d.ts`
+
+Vite client type reference.
+
+## `public/`
+
+Static assets served as-is (default `vite.svg` favicon).
+
+## Config files
+
+- **`vite.config.ts`** — React plugin, `base: "./"`, `outDir: "dist"`, excludes `lucide-react` from deps optimization.
+- **`tailwind.config.js`** — scans `index.html` and `src/**/*.{js,ts,jsx,tsx}`.
+- **`tsconfig.json`, `tsconfig.app.json`, `tsconfig.node.json`** — TypeScript project references.
+- **`postcss.config.js`** — Tailwind + Autoprefixer pipeline.

--- a/basic-3d-firstpersonview-multiplay/PROJECT/Context.md
+++ b/basic-3d-firstpersonview-multiplay/PROJECT/Context.md
@@ -1,0 +1,28 @@
+# Context — basic-3d-firstpersonview-multiplay
+
+## Project Overview
+
+Three.js + React Three Fiber scaffold for a multiplayer first-person shooter. Networking is wired end-to-end through `@agent8/gameserver`: `App.tsx` orchestrates nickname → room → lobby → in-game flow, `NetworkContainer` subscribes to room user states and spawns `RemotePlayer` instances, and `Player` throttles its own transform and animation state up to the server. First-person camera, pointer lock, and crosshair are driven by `vibe-starter-3d`'s `FirstPersonViewController`, and bullets fired by the local player are broadcast and reconciled through `effectStore` with damage reported via a `applyDamage` remote function.
+
+## Tech Stack
+
+_Exact versions are in `package.json`._
+
+- **Rendering**: Three.js, `@react-three/fiber`, `@react-three/drei`
+- **Physics**: `@react-three/rapier`, `@dimforge/rapier3d-compat`
+- **Character framework**: `vibe-starter-3d` (`FirstPersonViewController`, `CharacterRenderer`, `NetworkObject`, `FollowLight`, `useControllerState`, `useMouseControls`)
+- **Multiplayer**: `@agent8/gameserver` (`useGameServer`, `useRoomState`, `useRoomAllUserStates`, `remoteFunction`, room/state subscriptions)
+- **State**: Zustand
+- **Utilities**: `lodash/throttle`, `lucide-react`
+- **Build / Lang**: Vite, TypeScript
+- **Styling**: Tailwind CSS
+
+## Critical Memory
+
+- The local `Player` renders with `visible={false}` — FPV requires the own character mesh to be hidden. Do not flip this.
+- Local transform + animation state is broadcast via `server.remoteFunction('updateMyState', ...)` throttled to 100 ms (`NETWORK_CONSTANTS.SYNC.INTERVAL_MS`) with dirty-checking thresholds. Remote players receive updates through `subscribeRoomAllUserStates` and apply them via `RemotePlayer.syncState` → `NetworkObject.syncTransform`.
+- Session flow is gated by two booleans from `subscribeRoomMyState`: `isReady` (set in lobby) and room-level `gameStarted` — only when both are true does `GameScene` mount.
+- Bullets are spawned locally through `effectStore.addEffect` and broadcast on the `'effect-event'` room channel; hits call the `applyDamage` remote function. Self-hits are filtered by comparing `sender` against the collider's `userData.account`.
+- Character model and animation URLs live in `src/assets.json`; `setCharacter` remote function persists the selection to the user state before the game starts.
+</content>
+</invoke>

--- a/basic-3d-firstpersonview-multiplay/PROJECT/Requirements.md
+++ b/basic-3d-firstpersonview-multiplay/PROJECT/Requirements.md
@@ -1,0 +1,20 @@
+# Requirements — basic-3d-firstpersonview-multiplay
+
+## Coding Patterns
+
+- Stores are concern-split (Zustand): `networkSyncStore` (server + RTT), `playerStore` (rigid-body registry), `effectStore` (local effect queue) — do not cross-write.
+- Session flow is owned by `App.tsx`; `scene/` components render one stage each (`NicknameSetup`, `RoomManager`, `LobbyRoom`, `GameScene`) and call back into `App` for transitions.
+- R3F goes under `components/r3f/`, DOM under `components/scene/` and `components/ui/`; `GameScene.tsx` is the only place that mounts the `Canvas`.
+- Local transform broadcasts go through the throttled `updateMyState` remote function only — keep the 100 ms interval and dirty-check thresholds (`POSITION_CHANGE_THRESHOLD`, `ROTATION_CHANGE_THRESHOLD`).
+- Remote player transforms are applied through `RemotePlayer.syncState` → `NetworkObject.syncTransform`; do not drive them via React state/props per-frame.
+- Effects are authored locally via `effectStore.addEffect` and mirrored across peers through the `'effect-event'` room channel; damage goes through the `applyDamage` remote function, not peer-to-peer.
+- No magic values — animation ids in `constants/character.ts`, input bindings in `constants/controls.ts`, effect types in `types/effect.ts`.
+
+## Known Issues / Constraints
+
+- The local `Player`'s `CharacterRenderer` must stay `visible={false}`; enabling it breaks the FPV illusion.
+- Pointer lock is requested on canvas `pointerdown` and is desktop-only — no mobile input path is provided.
+- Remote functions used by the client (`joinRoom`, `leaveRoom`, `toggleReady`, `setCharacter`, `updateMyState`, `applyDamage`, `revive`, `handlePing`) must exist on the Agent8 game server; they are not part of this repository.
+- `vibe-starter-3d`'s `FirstPersonViewController` owns camera and movement; there is no local override.
+- The physics-ready raycast gate used in other templates is not present here — `Physics` runs immediately once `GameScene` mounts.
+</content>

--- a/basic-3d-firstpersonview-multiplay/PROJECT/Status.md
+++ b/basic-3d-firstpersonview-multiplay/PROJECT/Status.md
@@ -1,0 +1,23 @@
+# Status — basic-3d-firstpersonview-multiplay
+
+## Implemented
+
+- Session flow: `NicknameSetup` → `RoomManager` (create/join) → `LobbyRoom` (character select + ready) → `GameScene`, driven by `App.tsx` and `@agent8/gameserver` subscriptions.
+- First-person camera and movement via `vibe-starter-3d`'s `FirstPersonViewController`, with pointer-lock requested on canvas `pointerdown`.
+- Local player animation state machine (IDLE, WALK, RUN, JUMP, PUNCH, HIT, DIE) driven by keyboard + action keys; DIE / revive flow synced through `subscribeRoomMyState` and `revive` remote function.
+- Throttled network sync (100 ms + dirty thresholds) of position, rotation, and state via `updateMyState` remote function.
+- Remote-player replication: `NetworkContainer` subscribes to all user states and spawns / removes `RemotePlayer` instances; transforms applied via `NetworkObject.syncTransform` with nickname billboards.
+- Bullet system: left-click fires a ray-cast `Bullet` from the camera direction (200 ms cooldown) with `MuzzleFlash`; hits spawn an `Explosion` and report damage through `applyDamage`; peers mirror bullets via `'effect-event'` room messages.
+- Lobby character preview rendered in a secondary R3F `Canvas` with `OrbitControls` and `CharacterPreview`.
+- RTT ping loop (`handlePing` every 3 s, 5-sample trimmed average) surfaced via the `RTT` overlay.
+- HTML crosshair overlay, leave-game button, and room-id display in `GameScene`.
+- Scene lighting: ambient + `FollowLight` + sunset `Environment`.
+- Flat `Floor` with a fixed `RigidBody` collider.
+
+## Installed but not wired
+
+- `@react-three/postprocessing` — no effect pipeline.
+- `lucide-react` — dependency present but no icon usage in the source tree.
+- `melee_attack`, `aim`, `shoot`, `aim_run` animations listed in `assets.json` — `CharacterState` only maps IDLE, WALK, RUN, JUMP, PUNCH, HIT, DIE.
+- World geometry beyond the flat `Floor` — no walls, cover, or spawn points.
+</content>

--- a/basic-3d-firstpersonview-multiplay/PROJECT/Structure.md
+++ b/basic-3d-firstpersonview-multiplay/PROJECT/Structure.md
@@ -1,111 +1,64 @@
-# Basic 3D First Person View (FPV) - FPS
+# Structure — basic-3d-firstpersonview-multiplay
 
-## Project Summary
+## `src/main.tsx`, `src/App.tsx`
 
-This project is a multi-player First Person View (FPV) 3D FPS game built using Three.js and React Three Fiber.
+Entry point and root component. `App` owns the session state machine: it reads `useGameServer`, wires the server into `networkSyncStore`, subscribes to room state (`gameStarted`) and my-state (`isReady`, `character`), and conditionally renders `NicknameSetup` → `RoomManager` → `LobbyRoom` → `GameScene`. Room actions (`joinRoom`, `leaveRoom`) are called via `server.remoteFunction`.
 
-## Implementation Strategy
+## `src/App.css`, `src/index.css`
 
-This project uses a **Three.js-based 3D approach** because:
+Component styles and global base (Tailwind directives).
 
-- It requires real-time 3D character animation and control
-- Three.js provides efficient 3D rendering in web browsers
-- React Three Fiber simplifies integration with React components
-- The vibe-starter-3d library provides essential character rendering and animation tools
+## `src/assets.json`
 
-Key technologies:
+Asset manifest — character model URLs (15 entries) and animation URLs (idle, walk, run, jump, punch, melee_attack, aim, shoot, aim_run, hit, die).
 
-- Three.js for 3D rendering
-- React Three Fiber for React integration
-- @react-three/rapier for physics simulation
-- @react-three/drei for useful Three.js helpers
-- vibe-starter-3d for character rendering and animation
-- Tailwind CSS for styling
+## `src/constants/`
 
-## Implemented Features
+- **`character.ts`** — `CharacterState` animation ids (IDLE, WALK, RUN, JUMP, PUNCH, HIT, DIE) and `DEFAULT_HEIGHT = 1.6`.
+- **`controls.ts`** — `keyboardMap` for `@react-three/drei`'s `KeyboardControls` (WASD/arrows, jump, run, action1–4).
 
-- Keyboard-controlled character movement (WASD/Arrow keys)
-- Attack by clicking the left mouse button
-- First person view camera that follows the character
-- Physics-based character movement with collision detection
-- 3D environment with floor
-- Pointer lock for immersive control
+## `src/stores/` (Zustand)
 
-## File Structure Overview
+- **`networkSyncStore.ts`** — holds the `GameServer` instance and runs a 3 s ping loop via `handlePing` remote function, maintaining a 5-sample RTT history with min/max trimming.
+- **`playerStore.ts`** — registry mapping account → `RigidBody` ref for both local and remote players (used by effect hit tests).
+- **`effectStore.ts`** — local queue of active effects (`BULLET`, `EXPLOSION`) with incrementing keys.
 
-### `src/main.tsx`
+## `src/types/`
 
-- Entry point for the application.
-- Sets up React rendering and mounts the `App` component.
+- **`user.ts`** — `UserState` (account, nickname, isReady, character, position/rotation/state, stats).
+- **`player.ts`** — `PlayerInputs` (derived input flags), `PlayerRef` (boundingBox accessor).
+- **`effect.ts`** — `EffectType` enum, `EffectData`, `ActiveEffect`, `EffectEventMessage`.
+- **`index.ts`** — barrel re-exports.
 
-### `src/App.tsx`
+## `src/utils/`
 
-- Main application component.
-- Configures the overall layout and includes the `RoomManager` component.
+- **`effectUtils.ts`** — builders for bullet / explosion effect configs (serializes Vector3 → arrays for network transport).
 
-### `src/App.css`
+## `src/components/scene/` (flow + DOM overlays)
 
-- Defines the main styles for the `App` component and its child UI elements.
+- **`NicknameSetup.tsx`** — nickname entry form, submits back to `App`.
+- **`RoomManager.tsx`** — create / join room form; delegates to `App`'s `onJoinRoom(roomId?)`.
+- **`LobbyRoom.tsx`** — subscribes via `useRoomAllUserStates`, lets the user pick a character (calls `setCharacter` remote function) and toggle ready (`toggleReady`). Renders a mini R3F `Canvas` with `CharacterPreview` + `OrbitControls` for the selected character.
+- **`GameScene.tsx`** — in-game shell. Mounts `KeyboardControls`, the R3F `Canvas` (with pointer-lock on `pointerdown`), `Physics`, `Experience`, `NetworkContainer`, `EffectContainer`. Renders the HTML crosshair, a "Leave Game" button, `RTT`, and room id.
 
-### `src/index.css`
+## `src/components/r3f/` (inside `Canvas`)
 
-- Defines global base styles, Tailwind CSS directives, fonts, etc., applied throughout the application.
+- **`Experience.tsx`** — ambient light + `FollowLight` + sunset `Environment`, wraps `Player` in `FirstPersonViewController` (`targetHeight = 1.6`), mounts `Floor`.
+- **`Player.tsx`** — local FPV character. Reads keyboard via `useKeyboardControls`, mouse via `useMouseControls`, transform via `useControllerState`. Determines `CharacterState` each frame, throttles `updateMyState` (100 ms + dirty threshold), fires bullets on left-click with a 200 ms cooldown using the camera's world direction, and subscribes to `subscribeRoomMyState` to react to server-driven DIE / revive transitions. `CharacterRenderer` is rendered with `visible={false}`.
+- **`RemotePlayer.tsx`** — other players. `forwardRef` exposing `syncState(state, position, rotation)`, which forwards to `NetworkObject.syncTransform`. Registers its rigid body in `playerStore` and stamps `userData.account` for hit attribution. Renders the nickname as a billboarded `Text`.
+- **`NetworkContainer.tsx`** — subscribes to `subscribeRoomState` (removal on user leave) and `subscribeRoomAllUserStates` (add/remove by `isReady`, forward transforms through refs). Creates / destroys `RemotePlayer` refs keyed by account.
+- **`CharacterPreview.tsx`** — IDLE-only `CharacterRenderer` used inside `LobbyRoom`'s preview canvas.
+- **`Floor.tsx`** — 100 × 100 fixed `RigidBody` ground plane.
+- **`EffectContainer.tsx`** — renders active effects from `effectStore`. Subscribes to the `'effect-event'` room channel to mirror remote bullets, calls `applyDamage` remote function on local-owned hits, and spawns a follow-up `EXPLOSION` effect at impact.
 
-### `src/assets.json`
+## `src/components/r3f/effects/`
 
-- File for managing asset metadata. (Currently empty)
+- **`Bullet.tsx`** — ray-cast projectile (`world.castRay` each frame), fires `onHit` with collider + rigid body, auto-removes on duration timeout.
+- **`BulletEffectController.tsx`** — parses serialized config, composes `Bullet` + `MuzzleFlash`.
+- **`MuzzleFlash.tsx`** — short-lived flame-petal flash at the spawn position.
+- **`Explosion.tsx`** — particle burst spawned on bullet impact.
 
-### `src/constants/`
+## `src/components/ui/`
 
-- Directory defining constant values used throughout the application.
-  - **`character.ts`**: Defines character-related settings (e.g., movement speed, jump height).
-  - **`controls.ts`**: Defines settings that map keyboard inputs (WASD, arrow keys, etc.) to corresponding actions (movement, firing, etc.).
-
-### `src/components/`
-
-- Directory managing React components categorized by function.
-
-  - **`r3f/`**: Contains 3D components related to React Three Fiber.
-
-    - **`CharacterPreview.tsx`**: Component for displaying a character preview in the UI.
-    - **`EffectContainer.tsx`**: Groups and manages various visual effect components like bullets, muzzle flash, and explosions.
-    - **`Experience.tsx`**: Main component responsible for the primary 3D scene configuration. Includes lighting, environment `Environment`, the floor `Floor` component, and the `FollowLight` component that provides dynamic lighting following the player. It also renders the `Player` component within the `FirstPersonViewController`.
-    - **`Floor.tsx`**: Defines and visually represents the ground plane in the 3D space. Has physical properties.
-    - **`NetworkContainer.tsx`**: Manages the local player `Player` and remote players `RemotePlayer` within the scene.
-    - **`Player.tsx`**: Represents the local player's character, handling movement, camera, and interactions based on user input and network state. Implements FirstPersonViewController logic.
-    - **`RemotePlayer.tsx`**: Represents other players in the game, synchronizing their state based on network updates.
-    - **`effects/`**: Sub-directory containing components related to visual effects.
-      - **`Bullet.tsx`**: Component defining the visual representation and behavior of bullets fired from the player.
-      - **`BulletEffectController.tsx`**: Manages the entire bullet effect system, including creation, state updates, and recycling (Object Pooling).
-      - **`Explosion.tsx`**: Component generating visual explosion effects.
-      - **`MuzzleFlash.tsx`**: Component that generates and manages the flash effect occurring at the muzzle when firing a gun.
-
-  - **`scene/`**: Contains components related to 3D scene setup and game state.
-
-    - **`GameScene.tsx`**: Sets up the React Three Fiber `Canvas` component (implementing the Pointer Lock feature), utilizes `KeyboardControls` for handling keyboard inputs, configures the physics simulation using the `Physics` component from `@react-three/rapier`, includes the network container `NetworkContainer`, effect container `EffectContainer` and loads the `Experience` component with `Suspense` to initialize the 3D rendering environment.
-    - **`LobbyRoom.tsx`**: Component that joins the Colyseus lobby room, displays the list of available game rooms, and provides UI for creating/joining rooms.
-    - **`NicknameSetup.tsx`**: UI component where the user enters their nickname and selects a character, utilizing `CharacterPreview`.
-    - **`RoomManager.tsx`**: Component responsible for Colyseus Room connection and state management. Conditionally renders `NicknameSetup`, `LobbyRoom`, `GameScene`, etc., based on the connection status with the server.
-
-  - **`ui/`**: Contains general UI components.
-    - **`RTT.tsx`**: UI component for displaying Round Trip Time (network latency).
-
-### `src/stores/`
-
-- Directory containing Zustand stores for application state management.
-  - **`effectStore.ts`**: Store that manages the state of visual effects like bullets and explosions (e.g., creation, active/inactive).
-  - **`networkSyncStore.ts`**: Store that manages network-related state synchronization, including player data and room status.
-  - **`playerStore.ts`**: Store that manages the local player's state, such as nickname, character selection, and input actions.
-
-### `src/types/`
-
-- Directory containing TypeScript type definitions.
-  - **`effect.ts`**: Defines types related to visual effects (Effect).
-  - **`index.ts`**: Exports types from within the `types` directory.
-  - **`player.ts`**: Defines types related to player data and state.
-  - **`user.ts`**: Defines types related to user information (e.g., session ID, nickname).
-
-### `src/utils/`
-
-- Directory containing utility functions used across the application.
-  - **`effectUtils.ts`**: Contains utility functions specifically related to managing and calculating visual effects.
+- **`RTT.tsx`** — reads `networkSyncStore.rtt` and shows current ping.
+</content>

--- a/basic-3d-firstpersonview/PROJECT/Context.md
+++ b/basic-3d-firstpersonview/PROJECT/Context.md
@@ -1,0 +1,27 @@
+# Context — basic-3d-firstpersonview
+
+## Project Overview
+
+Three.js + React Three Fiber scaffold with a physics-based first-person character controller, pointer-lock aiming, and an effect pipeline wired for shooting. Player runs on `RigidBodyPlayer` with `CharacterRenderer` rendered invisible (FPV); camera follows via `FirstPersonViewController`; left-click fires bullets spawned at the camera along its forward vector, routed through a Zustand-backed effect store. Zustand stores are pre-split for multiplayer, and `@agent8/gameserver` is installed but no networking is wired.
+
+## Tech Stack
+
+_Exact versions are in `package.json`._
+
+- **Rendering**: Three.js, `@react-three/fiber`, `@react-three/drei`
+- **Physics**: `@react-three/rapier`
+- **Character framework**: `vibe-starter-3d` (`FirstPersonViewController`, `RigidBodyPlayer`, `CharacterRenderer`, `RigidBodyObject`, `FollowLight`)
+- **Multiplayer (unwired)**: `@agent8/gameserver`
+- **State**: Zustand
+- **Build / Lang**: Vite, TypeScript
+- **Styling**: Tailwind CSS
+
+## Critical Memory
+
+- Player must be built on `RigidBodyPlayer` and camera on `FirstPersonViewController`; the physics bootstrap depends on this pipeline.
+- `CharacterRenderer` on the local player must stay `visible={false}` — the FPV camera sits inside the character.
+- Physics stay paused until `gameStore.isMapPhysicsReady` is `true`. `MapPhysicsReadyChecker` releases it via a downward raycast — new map geometry must be reachable by it.
+- Shooting flows through `effectStore.addEffect` → `EffectContainer` → `BulletEffectController`; do not spawn bullets as ad-hoc R3F children.
+- Bullet hit detection is via `RigidBodyObject` sensor triggers; the firer is excluded by passing the player `RigidBody` as `owner`.
+- Handle player collisions via `RigidBodyPlayer.onTriggerEnter` / `onTriggerExit`, switching on `RigidBodyObjectType` tags.
+- Character model and animation URLs are loaded via the `src/assets.json` manifest.

--- a/basic-3d-firstpersonview/PROJECT/Requirements.md
+++ b/basic-3d-firstpersonview/PROJECT/Requirements.md
@@ -1,0 +1,18 @@
+# Requirements — basic-3d-firstpersonview
+
+## Coding Patterns
+
+- Stores are concern-split (Zustand): `gameStore`, `localPlayerStore`, `multiPlayerStore`, `playerActionStore`, `effectStore` — do not cross-write.
+- R3F goes under `components/r3f/`, DOM under `components/ui/`; `GameScene.tsx` stitches them and must not render 3D directly.
+- Spawn visual effects through `effectStore.addEffect` and let `EffectContainer` render them; add new effect types by extending `EffectType`, the container's `switch`, and a `create*EffectConfig` util.
+- Effect store payloads are plain JSON — serialize `THREE.Vector3` via `toArray()` / `toVector3Array`, not live objects.
+- Extend `Player.tsx` by adding animation states / action branches, not by forking.
+- No magic values — animation ids in `constants/character.ts`, rigid-body types in `constants/rigidBodyObjectType.ts`.
+
+## Known Issues / Constraints
+
+- `vibe-starter-3d` owns camera and movement bindings via `FirstPersonViewController` + `useInputStore`; action keys are mapped locally in `InputController.tsx`.
+- `MapPhysicsReadyChecker` has a 180-frame raycast timeout — very slow map loads may expire it.
+- Pointer lock is desktop-only (guarded by `IS_MOBILE`); FPV aim on mobile relies on touch look handled by the controller.
+- Local `CharacterRenderer` must stay `visible={false}` — flipping it breaks the FPV illusion (camera is inside the capsule).
+- `Bullet` uses a sensor `RigidBodyObject` with a short freeze window on hit; very high-speed bullets past a frame's raycast distance may miss thin geometry.

--- a/basic-3d-firstpersonview/PROJECT/Status.md
+++ b/basic-3d-firstpersonview/PROJECT/Status.md
@@ -1,0 +1,21 @@
+# Status — basic-3d-firstpersonview
+
+## Implemented
+
+- First-person camera (`FirstPersonViewController`) with invisible local `CharacterRenderer`
+- Physics-based character controller (`RigidBodyPlayer`) with extended humanoid animation set (idle, walk, run, fast run, jump, punch, kick, melee attack, cast, hit, dance, swim, die)
+- Left-click shooting: camera-forward bullet spawn with cooldown, routed through `effectStore`
+- Effect pipeline: `EffectContainer` + `BulletEffectController` + `Bullet` (sensor + raycast) + `MuzzleFlash` + `Explosion` on hit
+- FPV crosshair overlay tracked to canvas center
+- Physics-ready bootstrap (`MapPhysicsReadyChecker` + `LoadingScreen`)
+- Desktop input (keyboard + mouse + pointer lock) and mobile input (`nipplejs` joystick + on-screen ATTACK / JUMP buttons)
+- Collision triggers via `RigidBodyPlayer.onTriggerEnter` / `onTriggerExit`
+- Scene lighting: ambient + `FollowLight` + sunset environment preset
+
+## Installed but not wired
+
+- `@agent8/gameserver` — `useGameServer().account` is read for player registration, but no networking / session / effect replication code
+- `@react-three/postprocessing` — no effect pipeline
+- `playerActionStore` fields `punch`, `kick`, `meleeAttack`, `cast` — declared but no input binds or animation triggers (only `attack` is wired)
+- `lucide-react` — imported as a dependency but unused in source
+- World geometry — only a flat `Floor`

--- a/basic-3d-firstpersonview/PROJECT/Structure.md
+++ b/basic-3d-firstpersonview/PROJECT/Structure.md
@@ -1,115 +1,63 @@
-# Basic 3D First Person View (FPV) - FPS
+# Structure — basic-3d-firstpersonview
 
-## Project Summary
+## `src/main.tsx`, `src/App.tsx`
 
-This project is a single-player First Person View (FPV) 3D FPS game built using Three.js and React Three Fiber.
+Entry point and root component. `App` renders `GameScene` inside a full-viewport container.
 
-## Implementation Strategy
+## `src/App.css`, `src/index.css`
 
-This project uses a **Three.js-based 3D approach** because:
+Component styles and global base (Tailwind directives, fonts).
 
-- It requires real-time 3D character animation and control
-- Three.js provides efficient 3D rendering in web browsers
-- React Three Fiber simplifies integration with React components
-- The vibe-starter-3d library provides essential character rendering and animation tools
+## `src/assets.json`
 
-Key technologies:
+Asset manifest — character model and animation URLs.
 
-- Three.js for 3D rendering
-- React Three Fiber for React integration
-- @react-three/rapier for physics simulation
-- @react-three/drei for useful Three.js helpers
-- vibe-starter-3d for character rendering and animation
-- Tailwind CSS for styling
+## `src/constants/`
 
-## Implemented Features
+- **`character.ts`** — animation state ids (idle, walk, run, jump, hit, die and extended action states used by the animation map).
+- **`rigidBodyObjectType.ts`** — rigid-body category enum (local player, enemy, monster, wall, obstacle, item, bullet, floor, …).
 
-- Keyboard-controlled character movement (WASD/Arrow keys)
-- Attack by clicking the left mouse button
-- First person view camera that follows the character
-- Physics-based character movement with collision detection
-- 3D environment with floor
-- Pointer lock for immersive control
-- FPS-style crosshair overlay for targeting
-- Rigid body object type system for physics collision detection
-- Map physics system initialization with loading screen
-- Automatic physics readiness detection through raycasting
+> Keyboard bindings and action mapping (incl. `Mouse0` → `attack`) live inline in `components/ui/InputController.tsx`; no local `controls.ts` ships.
 
-## File Structure Overview
+## `src/stores/` (Zustand)
 
-### `src/main.tsx`
+- **`gameStore.ts`** — global lifecycle; holds `isMapPhysicsReady`.
+- **`localPlayerStore.ts`** — local-player state (position etc.).
+- **`multiPlayerStore.ts`** — registry of remote-player rigid-body refs; consumed by `EffectContainer` to resolve effect owners.
+- **`playerActionStore.ts`** — transient action flags (punch, kick, meleeAttack, cast, attack).
+- **`effectStore.ts`** — active visual-effect list with key counter; `addEffect` / `removeEffect` and `useActiveEffects` selector.
 
-- Entry point for the application.
-- Sets up React rendering and mounts the `App` component.
+## `src/types/`
 
-### `src/App.tsx`
+- **`effect.ts`** — `EffectType` enum (`BULLET`, `EXPLOSION`), `EffectData`, `ActiveEffect`, `EffectEventMessage`.
+- **`index.ts`** — re-exports.
 
-- Main application component.
-- Configures the overall layout and includes the `GameScene` component.
+## `src/utils/`
 
-### `src/App.css`
+- **`effectUtils.ts`** — `createBulletEffectConfig`, `createExplosionEffectConfig`; serialize `THREE.Vector3` to arrays for store payloads.
 
-- Defines the main styles for the `App` component and its child UI elements.
+## `src/components/r3f/` (inside `Canvas`)
 
-### `src/index.css`
+- **`GameSceneCanvas.tsx`** — R3F `Canvas` root. Hosts Rapier `Physics` (paused until `isMapPhysicsReady`), `FirstPersonViewController`, lighting (ambient + `FollowLight`), sunset `Environment`, and mounts `MapPhysicsReadyChecker`, `EffectContainer`, `Player`, `Floor`. Requests desktop pointer-lock on `pointerdown`.
+- **`MapPhysicsReadyChecker.tsx`** — raycasts downward each frame to detect map geometry; flips `isMapPhysicsReady` on hit or after a 180-frame timeout. Ignores capsules and sensor colliders.
+- **`Player.tsx`** — wraps `RigidBodyPlayer` + `CharacterRenderer` (visible=false). Owns animation-state determination, trigger-based collision handling, and left-click shooting: reads `attack` from `playerActionStore`, uses camera forward to build a bullet config, calls `effectStore.addEffect(BULLET, ...)` with a cooldown.
+- **`Floor.tsx`** — flat ground plane as a `RigidBodyObject` tagged `FLOOR`.
+- **`EffectContainer.tsx`** — subscribes to `useActiveEffects`; renders a `BulletEffectController` or `Explosion` per entry, resolves `owner` via `multiPlayerStore`, and on bullet hit spawns an explosion at the hit point.
 
-- Defines global base styles, Tailwind CSS directives, fonts, etc., applied throughout the application.
+## `src/components/r3f/effects/`
 
-### `src/assets.json`
+- **`BulletEffectController.tsx`** — parses store config back to `THREE.Vector3`, offsets the start along direction, mounts `Bullet` and (optionally) `MuzzleFlash`. Defines `BulletEffectConfig`.
+- **`Bullet.tsx`** — kinematic-velocity `RigidBodyObject` sensor tagged `BULLET`. Per-frame raycasts forward, freezes on hit (up to 3 frames), translates to hit point, and fires `onHit` via trigger enter; excludes its own collider and the firer `owner`. 150 ms visibility delay and lifetime-based removal.
+- **`MuzzleFlash.tsx`** — short-lived additive-blended flash at the muzzle; cone petals + inner glow with opacity falloff.
+- **`Explosion.tsx`** — two-group instanced particle burst with 500 ms fade; completes itself.
 
-- File for managing asset metadata. (Currently empty)
+## `src/components/scene/`
 
-### `src/constants/`
+- **`GameScene.tsx`** — layout shell stitching `GameSceneCanvas` (3D) and `GameSceneUI` (DOM overlay). Contains performance-critical warnings against mixing concerns.
 
-- Directory defining constant values used throughout the application.
-  - **`character.ts`**: Defines character-related settings (e.g., movement speed, jump height).
-  - **`controls.ts`**: Defines settings that map keyboard inputs (WASD, arrow keys, etc.) to corresponding actions (movement, firing, etc.).
-  - **`rigidBodyObjectType.ts`**: Defines constant values for different types of rigid body objects in the physics simulation (e.g., LOCAL_PLAYER, ENEMY, WALL, BULLET, FLOOR, etc.).
+## `src/components/ui/` (DOM overlay)
 
-### `src/components/`
-
-- Directory managing React components categorized by function.
-
-  - **`r3f/`**: Contains 3D components related to React Three Fiber.
-
-    - **`EffectContainer.tsx`**: Groups and manages various visual effect components like bullets and muzzle flash.
-    - **`Experience.tsx`**: Main component responsible for the primary 3D scene configuration. Sets up ambient lighting, environment preset (sunset), and includes the `Player` and `Floor` components.
-    - **`Floor.tsx`**: Defines and visually represents the ground plane in the 3D space. Has physical properties.
-    - **`GameSceneCanvas.tsx`**: React Three Fiber Canvas component that renders the 3D game world with physics simulation and controller setup.
-    - **`MapPhysicsReadyChecker.tsx`**: Component that checks if the map physics system is ready by performing raycasting from above downward to detect map geometry and ensures physics interactions are properly initialized before gameplay begins. Performs checks every frame until valid map geometry is detected, with a timeout after 180 frames to prevent infinite checking. Excludes Capsule shapes (likely characters/objects) and sensor colliders from the inspection.
-    - **`Player.tsx`**: Component defining the player character using the `RigidBodyPlayer` component from vibe-starter-3d. Handles player state management, animation configurations, shooting mechanics, and object interactions through `onTriggerEnter` and `onTriggerExit` events. The character is set to invisible for FPS view, and includes comprehensive collision detection with other rigid body objects using the RigidBodyObjectType system.
-    - **`effects/`**: Sub-directory containing components related to visual effects.
-      - **`Bullet.tsx`**: Component defining the visual representation and behavior of bullets fired from the player.
-      - **`BulletEffectController.tsx`**: Manages the entire bullet effect system, including creation, state updates, and recycling (Object Pooling).
-      - **`Explosion.tsx`**: Component that creates and manages explosion visual effects.
-      - **`MuzzleFlash.tsx`**: Component that generates and manages the flash effect occurring at the muzzle when firing a gun.
-
-  - **`scene/`**: Contains components related to scene setup.
-
-    - **`GameScene.tsx`**: Main game scene component that serves as a layout container arranging the game UI and 3D Canvas. Contains critical performance warnings and guidelines to prevent re-rendering issues. Includes the `GameSceneCanvas` and `GameSceneUI` components in a proper layered structure where the Canvas renders the 3D world and UI components render as overlays.
-
-  - **`ui/`**: Contains UI components for the game interface.
-    - **`Crosshair.tsx`**: Renders a centered crosshair overlay for FPS-style targeting with white lines and black outline for better visibility across different backgrounds.
-    - **`GameSceneUI.tsx`**: Component that manages UI overlays for the game scene.
-    - **`LoadingScreen.tsx`**: Loading screen component displayed during game loading.
-    - **`InputController.tsx`**: Manages all input handling including keyboard, mouse, and touch controls with virtual joystick support for mobile devices and action buttons for FPS-style attack controls and movement.
-
-### `src/stores/`
-
-- Directory containing Zustand stores for application state management.
-  - **`effectStore.ts`**: Store that manages the state of visual effects like bullets (e.g., creation, active/inactive).
-  - **`gameStore.ts`**: Store that manages the overall game state. Tracks and controls the readiness state of the map physics system (`isMapPhysicsReady`). This state is used to determine physics simulation pause/resume and loading screen display.
-  - **`localPlayerStore.ts`**: Store that manages the local player's state, such as position tracking.
-  - **`multiPlayerStore.ts`**: Store that manages multiple connected players' rigid body references for multiplayer functionality, including registration, unregistration, and retrieval of player references.
-- **`playerActionStore.ts`**: Store that manages player action states including combat actions (punch, kick, meleeAttack, cast) with support for setting, getting, and resetting action states.
-
-### `src/types/`
-
-- Directory containing TypeScript type definitions.
-  - **`effect.ts`**: Defines types related to visual effects (Effect).
-  - **`index.ts`**: Exports types from within the `types` directory.
-
-### `src/utils/`
-
-- Directory containing utility functions used throughout the application.
-  - **`effectUtils.ts`**: Provides utility functions for creating effect configurations, such as bullet and explosion effects.
+- **`GameSceneUI.tsx`** — UI overlay container; gates `Crosshair` on `isMapPhysicsReady` and mounts `InputController`.
+- **`LoadingScreen.tsx`** — shown while `isMapPhysicsReady` is `false`.
+- **`Crosshair.tsx`** — centered FPV crosshair; tracks canvas center via `resize` / `orientationchange` / `scroll`.
+- **`InputController.tsx`** — keyboard + mouse + touch input. Maps WASD/arrows/space/shift to `useInputStore`, maps `Mouse0` → `attack` into `playerActionStore`. On mobile renders a `nipplejs` joystick on the left half of the screen and on-screen `ATTACK` / `JUMP` buttons.

--- a/basic-3d-flightview-multiplay/PROJECT/Context.md
+++ b/basic-3d-flightview-multiplay/PROJECT/Context.md
@@ -1,0 +1,25 @@
+# Context — basic-3d-flightview-multiplay
+
+## Project Overview
+
+Three.js + React Three Fiber scaffold for a multiplayer flight game. Aircraft control is driven by `FlightViewController` from `vibe-starter-3d`, and `@agent8/gameserver` is fully wired for networking — nickname setup, room lobby, ready/start flow, transform sync, bullet/explosion effect events, and RTT measurement are all connected. Remote players are rendered via `NetworkObject`-wrapped `Aircraft` clones and synchronized through server state subscriptions.
+
+## Tech Stack
+
+_Exact versions are in `package.json`._
+
+- **Rendering**: Three.js, `@react-three/fiber`, `@react-three/drei`
+- **Physics**: `@react-three/rapier`
+- **Flight framework**: `vibe-starter-3d` (`FlightViewController`, `NetworkObject`, `FollowLight`, `useControllerState`)
+- **Multiplayer**: `@agent8/gameserver`
+- **State**: Zustand
+- **Build / Lang**: Vite, TypeScript
+- **Styling**: Tailwind CSS
+
+## Critical Memory
+
+- `App.tsx` drives the top-level flow: connect → `NicknameSetup` → `RoomManager` → `LobbyRoom` (ready toggle) → `GameScene`. Do not bypass this sequence when adding screens.
+- Local player must stay wrapped in `<FlightViewController>` inside `Experience.tsx`; `Player.tsx` reads transforms through `useControllerState()`, not directly from refs.
+- Network transform sync in `Player.tsx` is throttle-gated by `NETWORK_CONSTANTS.SYNC` (100 ms interval, position/rotation thresholds). Remote `Aircraft` rendering goes through `NetworkContainer` → `RemotePlayer` → `NetworkObject.syncTransform`.
+- Effects are dual-pathed: add locally via `useEffectStore.addEffect` and broadcast via `server.remoteFunction('sendEffectEvent', ...)`. Incoming `effect-event` room messages are replayed through the same store in `EffectContainer`.
+- RTT is owned by `networkSyncStore` — `App.tsx` sets the server reference, which auto-starts the ping loop; do not start it manually elsewhere.

--- a/basic-3d-flightview-multiplay/PROJECT/Requirements.md
+++ b/basic-3d-flightview-multiplay/PROJECT/Requirements.md
@@ -1,0 +1,21 @@
+# Requirements — basic-3d-flightview-multiplay
+
+## Coding Patterns
+
+- Top-level screen routing lives only in `App.tsx`. New screens extend the `renderContent()` switch and must not call `server.remoteFunction('joinRoom' | 'leaveRoom', ...)` from elsewhere.
+- Local-player transform comes from `useControllerState()` (never read a ref directly). Outgoing state goes through the `throttledSyncToNetworkTransform` in `Player.tsx` — extend that path, do not open a second sync channel.
+- Remote players are imperatively updated via `RemotePlayerHandle.syncState` in `NetworkContainer`. Do not move to prop-driven transforms on `RemotePlayer`.
+- Effects follow the dual-path rule: `useEffectStore.addEffect(...)` locally + `server.remoteFunction('sendEffectEvent', [type, config])` outbound. Inbound `effect-event` messages replay into the same store in `EffectContainer`.
+- Effect configs must be wire-safe — serialize vectors with `createBulletEffectConfig` / `createExplosionEffectConfig` in `utils/effectUtils.ts`.
+- Stores are concern-split: `playerStore` (RigidBody refs), `effectStore` (effect queue), `networkSyncStore` (server + RTT). Do not cross-write.
+- No magic values: aircraft states in `constants/aircraft.ts`, key bindings in `constants/controls.ts`, effect types in `types/effect.ts`.
+- R3F components live under `components/r3f/`, scene/screen components under `components/scene/`, DOM overlays under `components/ui/`. `GameScene.tsx` is the only place that mixes DOM and `Canvas`.
+
+## Known Issues / Constraints
+
+- Server contract is implicit. The client calls remote functions `joinRoom`, `leaveRoom`, `toggleReady`, `updateMyState`, `sendEffectEvent`, `applyDamage`, `revive`, `handlePing`, and expects `UserState` shape with `stats.maxHp` / `stats.currentHp` — the server implementation must honor these.
+- `subscribeRoomAllUserStates` only renders remote players that are both `isReady` and have a `position`; players without a position are silently skipped.
+- Bullet hit resolution runs on the shooter's client only (`sender === account` gate in `EffectContainer`) — damage is authoritative-by-shooter, not server-validated.
+- `FlightViewController` is configured with `minSpeed=0, maxSpeed=120, hitBodySize=[1, 0.6, 3]` in `Experience.tsx`; changing `HIT_BODY_SIZE` in `constants/aircraft.ts` does not propagate automatically.
+- `Ground.tsx` has only the "SEA" plane as a physics body; the visible green ground is a non-collidable mesh, so aircraft can pass through it.
+- Pointer lock is requested unconditionally on pointerdown in `GameScene` — no mobile / touch guard.

--- a/basic-3d-flightview-multiplay/PROJECT/Status.md
+++ b/basic-3d-flightview-multiplay/PROJECT/Status.md
@@ -1,0 +1,21 @@
+# Status — basic-3d-flightview-multiplay
+
+## Implemented
+
+- End-to-end session flow: connect → nickname → room create/join → lobby ready → game scene (`App.tsx` + `NicknameSetup` + `RoomManager` + `LobbyRoom` + `GameScene`)
+- Flight control via `FlightViewController` (WASD yaw/throttle, arrow keys pitch/roll) with propeller-speed-reactive visuals
+- Multiplayer transform sync: throttled `updateMyState` outbound, `subscribeRoomAllUserStates` inbound, imperative `RemotePlayer.syncState`
+- Remote player rendering through `NetworkObject` + nickname `Billboard` + cuboid hit collider
+- Bullet + muzzle-flash + explosion effect pipeline, dual-pathed via `effectStore` and `sendEffectEvent` / `effect-event` room messages
+- Shooter-side hit resolution calling `applyDamage`
+- Death / revive loop driven by `AircraftState.DIE` in `subscribeRoomMyState`, with automatic `revive` call
+- RTT ping loop via `networkSyncStore` (3 s interval, outlier-trimmed 5-sample average) and on-screen `RTT` badge
+- HP / speed / altitude / player-count HUD (`StatusDisplay`)
+- World dressing: sea plane with collider, runway, 500 scattered decoration meshes, 150 kinematic floating shapes (balloon / bird / plane)
+
+## Installed but not wired
+
+- `@react-three/postprocessing` — no effect pipeline is mounted
+- `lucide-react` — imported nowhere
+- `src/assets.json` — character / animation manifest not consumed (aircraft scene uses primitive geometry)
+- `FlightViewController` mobile / touch input — desktop keyboard + pointer lock only

--- a/basic-3d-flightview-multiplay/PROJECT/Structure.md
+++ b/basic-3d-flightview-multiplay/PROJECT/Structure.md
@@ -1,115 +1,65 @@
-# Basic 3D Flight View
+# Structure — basic-3d-flightview-multiplay
 
-## Project Summary
+## `src/main.tsx`, `src/App.tsx`
 
-This project is a multi-player game where you can control and fly an aircraft in a 3D space. It is built using Three.js and React Three Fiber.
+Entry point and root flow controller. `App` uses `useGameServer` from `@agent8/gameserver`, wires `networkSyncStore.setServer`, and switches between `NicknameSetup`, `RoomManager`, `LobbyRoom`, and `GameScene` based on connection / nickname / room / `roomStarted` / `isReady` state. Exposes `joinRoom`, `leaveRoom` remote-function calls and subscribes to `subscribeRoomState` + `subscribeRoomMyState`.
 
-## Implementation Strategy
+## `src/App.css`, `src/index.css`
 
-This project uses a **Three.js-based 3D approach** because:
+Component styles and global base (Tailwind directives).
 
-- It requires real-time 3D character animation and control
-- Three.js provides efficient 3D rendering in web browsers
-- React Three Fiber simplifies integration with React components
-- The vibe-starter-3d library provides essential character rendering and animation tools
+## `src/assets.json`
 
-Key technologies:
+Asset manifest — character / animation URLs. Not used by the current aircraft scene but shipped for future extension.
 
-- Three.js for 3D rendering
-- React Three Fiber for React integration
-- @react-three/rapier for physics simulation
-- @react-three/drei for useful Three.js helpers
-- vibe-starter-3d for character rendering and animation
-- @agent8/gameserver for multiplayer functionality
-- Zustand for state management
-- Tailwind CSS for styling
+## `src/constants/`
 
-## Implemented Features
+- **`aircraft.ts`** — `AircraftState` enum (`ACTIVE`, `DIE`), `DEFAULT_BODY_LENGTH`, `HIT_BODY_SIZE`.
+- **`controls.ts`** — keyboard map for `KeyboardControls`: forward/back, yawLeft/yawRight, pitchUp/pitchDown, rollLeft/rollRight, attack (Space), action1–4.
 
-- Keyboard-controlled character movement (WASD/Arrow keys) and attack (Spacebar)
-- Free view camera that follows the character
-- Pointer lock for immersive control
+## `src/stores/` (Zustand)
 
-## File Structure Overview
+- **`playerStore.ts`** — `usePlayerStore`: registry of local + remote player `RigidBody` refs keyed by account.
+- **`effectStore.ts`** — `useEffectStore`: `activeEffects` list with `addEffect` / `removeEffect` and monotonic `effectKeyCounter`.
+- **`networkSyncStore.ts`** — `networkSyncStore`: holds `GameServer`, drives a 3 s ping loop against `handlePing`, keeps last 5 RTT samples and an outlier-trimmed average.
 
-This overview details the key files and directories within the `src/` directory.
+## `src/types/`
 
-### `src/main.tsx`
+- **`user.ts`** — `UserState` (account, nickname, isReady, position, rotation, state, stats with `maxHp` / `currentHp`).
+- **`player.ts`** — `PlayerInputs` flags (isRevive, isDying, isHit, isMoving).
+- **`effect.ts`** — `EffectType` (`BULLET`, `EXPLOSION`), `EffectData`, `ActiveEffect`, `EffectEventMessage`.
+- **`index.ts`** — barrel exports.
 
-- Entry point for the React application.
-- Sets up React rendering and mounts the `App` component.
+## `src/utils/effectUtils.ts`
 
-### `src/App.tsx`
+`createBulletEffectConfig` and `createExplosionEffectConfig` — serialize `THREE.Vector3` into plain arrays so effect configs can travel over the wire.
 
-- Main application component.
-- Configures the overall layout, routing (using `RoomManager`), and includes UI components.
+## `src/components/r3f/` (inside `Canvas`)
 
-### `src/App.css`
+- **`Experience.tsx`** — 3D scene root. Ambient light + `FollowLight` + `Sky`, wraps `<Player>` in `<FlightViewController minSpeed={0} maxSpeed={120} hitBodySize=[1, 0.6, 3]>`, and mounts `Ground` and `FloatingShapes`.
+- **`Player.tsx`** — local-player logic. Pulls transform via `useControllerState`, registers the ref in `usePlayerStore`, subscribes to `subscribeRoomMyState` to toggle `AircraftState.DIE` / revive, throttle-syncs transform via `updateMyState`, fires bullets on `attack` input (200 ms cooldown) through `useEffectStore.addEffect` + `sendEffectEvent`. Renders `<Aircraft localPlayer>` when alive.
+- **`Aircraft.tsx`** — visual-only aircraft model (body, cockpit, wings, tail, propeller, twin `Trail`s). Propeller spin rate tracks `userData.speed` for the local player.
+- **`RemotePlayer.tsx`** — `forwardRef` wrapper around `NetworkObject` + `CuboidCollider` + `<Aircraft>` + nickname `Billboard`. Exposes `syncState(state, position, rotation)` via `useImperativeHandle` so `NetworkContainer` can push transforms imperatively.
+- **`NetworkContainer.tsx`** — subscribes to `subscribeRoomState` (user leave cleanup) and `subscribeRoomAllUserStates`, maintains a `RemotePlayerHandle` ref map keyed by account, and drives `syncState` on every update. Skips self and non-ready players.
+- **`EffectContainer.tsx`** — Zustand-driven renderer for `activeEffects`. Routes `BULLET` to `BulletEffectController` and `EXPLOSION` to `Explosion`. Listens to room `effect-event` messages, adds incoming effects locally, and on local bullet hits calls `applyDamage` + spawns an explosion.
+- **`Ground.tsx`** — fixed sea plane (`RigidBody` "SEA"), visual ground, runway stripes, 500 procedurally-scattered decoration meshes.
+- **`FloatingShapes.tsx`** — 150 kinematic balloons / birds / planes with oscillate / circle / drift motion profiles driven in `useFrame`.
 
-- Styles specific to the `App` component.
+### `src/components/r3f/effects/`
 
-### `src/index.css`
+- **`Bullet.tsx`** — ray-cast projectile. Uses `useRapier`'s `world.castRay` each frame, calls `onHit(pos, rigidBody, collider)` and `onComplete` on impact or timeout.
+- **`BulletEffectController.tsx`** — parses effect config, offsets the start position, renders `<Bullet>` + optional `<MuzzleFlash>`.
+- **`MuzzleFlash.tsx`** — short-lived additive-blended petal / inner-glow cone group with opacity fade.
+- **`Explosion.tsx`** — two groups of `instancedMesh` particles (`white`, `grey`) that drift outward and fade over 500 ms.
 
-- Global styles, including Tailwind CSS directives and base styles.
+## `src/components/scene/`
 
-### `src/assets.json`
+- **`GameScene.tsx`** — in-game shell. Renders a Leave button + `RTT` + room-id banner, mounts `StatusDisplay`, then a `KeyboardControls` + `Canvas` (pointer-lock on pointerdown) containing `Physics` → `Suspense` → `Experience` + `NetworkContainer` + `EffectContainer`.
+- **`RoomManager.tsx`** — create-new-room / join-by-id form shown after nickname setup.
+- **`LobbyRoom.tsx`** — pre-game lobby. Lists all users via `useRoomAllUserStates`, toggles `isReady` through `server.remoteFunction('toggleReady', [])`.
+- **`NicknameSetup.tsx`** — nickname entry form; surfaces loading + error state from `App`.
 
-- Metadata for assets (currently may be unused or planned for future use).
+## `src/components/ui/` (DOM overlay)
 
-### `src/constants/`
-
-- Directory defining constant values used throughout the application.
-  - **`aircraft.ts`**: Defines constants related to aircraft properties.
-  - **`controls.ts`**: Maps keyboard inputs to game actions (e.g., movement, firing).
-
-### `src/components/`
-
-- React components categorized by function.
-
-  - **`r3f/`**: React Three Fiber components for the 3D scene.
-
-    - **`Player.tsx`**: Logic for the player-controlled character (movement, animation, potentially includes aircraft logic).
-    - **`Aircraft.tsx`**: Logic for the player-controlled airplane model and behavior (movement, rotation, firing).
-    - **`RemotePlayer.tsx`**: Logic for rendering and synchronizing remote players.
-    - **`Experience.tsx`**: Main component responsible for the primary 3D scene configuration. It sets up the sky environment using `Sky` from `@react-three/drei` and provides basic lighting with `ambientLight`. It utilizes `FlightViewController` from `vibe-starter-3d` to wrap the `Player` component, handling flight control logic. It also includes the `Ground`, `FloatingShapes`, and `FollowLight` components to complete the scene. The `FollowLight` component provides a light source that follows the player.
-    - **`FloatingShapes.tsx`**: Manages floating 3D shapes in the scene.
-    - **`Ground.tsx`**: Defines the ground plane with physical properties.
-    - **`EffectContainer.tsx`**: Manages visual effects rendering.
-    - **`NetworkContainer.tsx`**: Handles network-related logic within the 3D scene.
-    - **`effects/`**: Specific visual effect components.
-      - **`Bullet.tsx`**: Visual representation and behavior of bullets.
-      - **`BulletEffectController.tsx`**: Manages bullet effect creation and lifecycle (potential for object pooling).
-      - **`MuzzleFlash.tsx`**: Represents the muzzle flash effect.
-      - **`Explosion.tsx`**: Represents the explosion effect.
-
-  - **`scene/`**: Components managing different application scenes or stages.
-
-    - **`GameScene.tsx`**: Sets up the React Three Fiber `Canvas` component (implementing the Pointer Lock feature), utilizes `KeyboardControls` for handling keyboard inputs, configures the physics simulation using the `Physics` component from `@react-three/rapier`, includes the network container `NetworkContainer`, effect container `EffectContainer` and loads the `Experience` component with `Suspense` to initialize the 3D rendering environment.
-    - **`RoomManager.tsx`**: Handles routing or switching between different rooms/scenes like Lobby, Game, etc., based on game state.
-    - **`LobbyRoom.tsx`**: Component representing the game lobby UI and logic (e.g., player list, room selection).
-    - **`NicknameSetup.tsx`**: Component for players to set up their nickname before entering the lobby or game.
-
-  - **`ui/`**: General user interface components.
-    - **`StatusDisplay.tsx`**: UI component displaying game state information (e.g., airplane speed, altitude) during gameplay.
-    - **`RTT.tsx`**: UI component for displaying Round Trip Time (network latency).
-
-### `src/stores/`
-
-- State management logic (using Zustand).
-  - **`playerStore.ts`**: Manages state related to the local player.
-  - **`effectStore.ts`**: Manages state related to visual effects (bullets, explosions).
-  - **`networkSyncStore.ts`**: Manages state synchronization for multiplayer functionality.
-
-### `src/types/`
-
-- TypeScript type definitions.
-
-  - **`effect.ts`**: Defines types for visual effects.
-  - **`user.ts`**: Defines types related to users/players.
-  - **`player.ts`**: Defines types specific to player data.
-  - **`index.ts`**: Exports types from the directory.
-
-### `src/utils/`
-
-- Directory containing utility functions used across the application.
-  - **`effectUtils.ts`**: Contains utility functions specifically related to managing and calculating visual effects.
+- **`StatusDisplay.tsx`** — reads `useControllerState` for speed / altitude, `subscribeRoomState` for player count, `subscribeRoomMyState` for HP. Renders control hints.
+- **`RTT.tsx`** — subscribes to `networkSyncStore.rtt` and shows ping in ms.

--- a/basic-3d-flightview/PROJECT/Context.md
+++ b/basic-3d-flightview/PROJECT/Context.md
@@ -1,0 +1,25 @@
+# Context — basic-3d-flightview
+
+## Project Overview
+
+Single-player flight scaffold built on Three.js + React Three Fiber + Rapier. The player rides a kinematic `RigidBodyPlayer` that wraps a procedural `Aircraft` mesh (body, wings, cockpit, spinning propeller with `Trail`); flight motion and camera follow are handled by `vibe-starter-3d`'s `FlightViewController`. Space fires bullets through a Zustand-backed effect pipeline (bullet → explosion), R spawns a reset, and `StatusDisplay` reads speed/altitude from `localPlayerStore` and HP/player count from `@agent8/gameserver`. Map physics are gated by a downward raycast until the world is reachable.
+
+## Tech Stack
+
+_Exact versions are in `package.json`._
+
+- **Rendering**: Three.js, `@react-three/fiber`, `@react-three/drei` (`Sky`, `Trail`, `Html`)
+- **Physics**: `@react-three/rapier`, `@dimforge/rapier3d-compat`
+- **Flight framework**: `vibe-starter-3d` (`FlightViewController`, `RigidBodyPlayer`, `RigidBodyObject`, `FollowLight`, `useControllerState`)
+- **Multiplayer**: `@agent8/gameserver` (used by `StatusDisplay` and `Player` for account / room state)
+- **State**: Zustand
+- **Build / Lang**: Vite, TypeScript
+- **Styling**: Tailwind CSS
+
+## Critical Memory
+
+- Player must ride `RigidBodyPlayer` and camera must come from `FlightViewController`; Physics stays paused until `gameStore.isMapPhysicsReady` flips.
+- `MapPhysicsReadyChecker` raycasts downward from `y = 50` and releases physics on the first non-sensor, non-Capsule hit, or after a 180-frame timeout — new map geometry must be reachable by that ray.
+- `Player` is kinematic (`type="kinematicPosition"`, `gravityScale={0}`, `sensor={true}`) and uses a manual `CuboidCollider` with `autoCreateCollider={false}`; collisions are handled via `onTriggerEnter` / `onTriggerExit` keyed on `RigidBodyObjectType`.
+- Bullet lifecycle flows `Player → effectStore.addEffect(BULLET) → EffectContainer → BulletEffectController → Bullet` and resolves hits back into `EffectContainer` which spawns `EXPLOSION`.
+- Flight key mapping is declared inline in `GameSceneCanvas.tsx` as a `FlightControllerKeyMapping`; `src/constants/controls.ts` exports a `KeyboardControlsEntry[]` that is currently unused.

--- a/basic-3d-flightview/PROJECT/Requirements.md
+++ b/basic-3d-flightview/PROJECT/Requirements.md
@@ -1,0 +1,19 @@
+# Requirements — basic-3d-flightview
+
+## Coding Patterns
+
+- Stores are concern-split (Zustand): `gameStore`, `localPlayerStore`, `multiPlayerStore`, `effectStore` — do not cross-write.
+- R3F goes under `components/r3f/`, DOM under `components/ui/`; `GameScene.tsx` stitches them and must not render 3D directly or hold state.
+- Extend behavior on `Player.tsx`; keep `Aircraft.tsx` as a pure visual/mesh component driven by props and `localPlayerStore`.
+- New visual effects: add an `EffectType` in `types/effect.ts`, a controller under `components/r3f/effects/`, and a `switch` case in `EffectContainer.tsx`. Spawn them via `effectStore.addEffect`, never by direct mount.
+- No magic values for categories — aircraft ids in `constants/aircraft.ts`, rigid-body tags in `constants/rigidBodyObjectType.ts`.
+- Local player speed is stored in m/s; convert with `× 3.6` at the UI boundary.
+
+## Known Issues / Constraints
+
+- Flight key bindings are declared inline in `GameSceneCanvas.tsx` (`FlightControllerKeyMapping`); `src/constants/controls.ts` is currently unused and must be wired manually if you want a single source of truth.
+- `MapPhysicsReadyChecker` has a 180-frame timeout and only fires a single ray straight down from `(0, 50, 0)` — maps whose geometry does not intersect that ray will fall through to the timeout path.
+- `Player` is a kinematic sensor with `gravityScale={0}` and `enabledRotations=[false,false,false]` — gravity, impulses, and dynamic rotations do not apply; motion and attitude are driven by `FlightViewController` via `useControllerState`.
+- Pointer lock is requested unconditionally on `pointerdown`; there is no mobile guard and no touch/joystick UI.
+- The bullet pipeline freezes a bullet for up to 3 frames after a hit to wait for `onTriggerEnter`; overlapping sensors may defer explosion spawn by that window.
+- `@react-three/postprocessing` is installed but no effect composer is mounted.

--- a/basic-3d-flightview/PROJECT/Status.md
+++ b/basic-3d-flightview/PROJECT/Status.md
@@ -1,0 +1,22 @@
+# Status — basic-3d-flightview
+
+## Implemented
+
+- Flight camera and controller (`FlightViewController`) with throttle (W/S), yaw (A/D), pitch (Arrow Up/Down), roll (Arrow Left/Right)
+- Kinematic player (`RigidBodyPlayer` + manual `CuboidCollider`) wrapping a procedural `Aircraft` mesh with wingtip `Trail`s and speed-reactive propeller
+- Physics-ready bootstrap (`MapPhysicsReadyChecker` + `LoadingScreen`) gating Rapier `Physics`
+- Bullet / explosion pipeline via `effectStore` → `EffectContainer` (`Bullet`, `BulletEffectController`, `MuzzleFlash`, `Explosion`); `Space` fires with a 200 ms cooldown, hits spawn an explosion at the contact point
+- Player reset on `R` (edge-triggered) via `useControllerState`
+- Local position + 5-frame averaged speed streaming into `localPlayerStore`
+- Multi-player rigid-body registry (`multiPlayerStore`) keyed by `@agent8/gameserver` account
+- HUD `StatusDisplay` showing player count, HP%, speed (km/h), altitude (m), and controls
+- World: `SEA` plane, grass `FLOOR`, runway with 100 lane markings, 500 scattered decor meshes, 150 `FloatingShapes` (balloon / bird / plane) with oscillate / circle / drift motion
+- Lighting and sky: ambient + `FollowLight` + drei `Sky`
+- Desktop pointer lock requested on canvas `pointerdown`
+
+## Installed but not wired
+
+- `@react-three/postprocessing` — no effect composer mounted
+- `lucide-react` — no icons referenced
+- `src/constants/controls.ts` — `KeyboardControlsEntry[]` exported but unused; flight keys live inline in `GameSceneCanvas`
+- Several `RigidBodyObjectType` tags (`ENEMY`, `MONSTER`, `WALL`, `OBSTACLE`, `ITEM`, `PLOTTING_BOARD`) and aircraft `DIE` state — defined but no behavior attached

--- a/basic-3d-flightview/PROJECT/Structure.md
+++ b/basic-3d-flightview/PROJECT/Structure.md
@@ -1,106 +1,58 @@
-# Basic 3D Flight View
+# Structure — basic-3d-flightview
 
-## Project Summary
+## `src/main.tsx`, `src/App.tsx`
 
-This project is a single-player game where you can control and fly an aircraft in a 3D space. It is built using Three.js and React Three Fiber.
+Entry point and root component. `App` renders `GameScene` inside a full-viewport container.
 
-## Implementation Strategy
+## `src/App.css`, `src/index.css`
 
-This project uses a **Three.js-based 3D approach** because:
+Component styles and global base (Tailwind directives, fonts).
 
-- It requires real-time 3D character animation and control
-- Three.js provides efficient 3D rendering in web browsers
-- React Three Fiber simplifies integration with React components
-- The vibe-starter-3d library provides essential character rendering and animation tools
+## `src/constants/`
 
-Key technologies:
+- **`aircraft.ts`** — aircraft state ids (`ACTIVE`, `DIE`), `DEFAULT_BODY_LENGTH`, `HIT_BODY_SIZE`.
+- **`controls.ts`** — `KeyboardControlsEntry[]` list (forward, yaw, pitch, roll, attack, reset, action1–4). Not currently wired; flight keys live inside `GameSceneCanvas`.
+- **`rigidBodyObjectType.ts`** — rigid-body category enum (`LOCAL_PLAYER`, `ENEMY`, `MONSTER`, `WALL`, `OBSTACLE`, `ITEM`, `BULLET`, `FLOOR`, `SEA`, `PLOTTING_BOARD`).
 
-- Three.js for 3D rendering
-- React Three Fiber for React integration
-- @react-three/rapier for physics simulation
-- @react-three/drei for useful Three.js helpers
-- vibe-starter-3d for character rendering and animation
-- @agent8/gameserver for multiplayer functionality
-- Zustand for state management
-- Tailwind CSS for styling
+## `src/types/`
 
-## Implemented Features
+- **`effect.ts`** — `EffectType` enum (`BULLET`, `EXPLOSION`), `EffectData`, `ActiveEffect`, `EffectEventMessage`.
+- **`index.ts`** — re-exports from `./effect`.
 
-- Keyboard-controlled aircraft movement (WASD/Arrow keys) and attack (Spacebar)
-- Free view camera that follows the aircraft
-- Pointer lock for immersive control
+## `src/utils/`
 
-## File Structure Overview
+- **`effectUtils.ts`** — `createBulletEffectConfig` and `createExplosionEffectConfig`; serialize `THREE.Vector3` into array form for the effect store.
 
-### `src/main.tsx`
+## `src/stores/` (Zustand)
 
-- Entry point for the application.
-- Sets up React rendering and mounts the `App` component.
+- **`gameStore.ts`** — global lifecycle; holds `isMapPhysicsReady`.
+- **`localPlayerStore.ts`** — local player position and speed (m/s; multiply by 3.6 for km/h).
+- **`multiPlayerStore.ts`** — registry of remote-player `RigidBody` refs.
+- **`effectStore.ts`** — queue of active effects (`activeEffects`) keyed by an incrementing counter; `addEffect` / `removeEffect`.
 
-### `src/App.tsx`
+## `src/components/r3f/` (inside `Canvas`)
 
-- Main application component and entry point.
-- Sets up a full-screen container and renders the `GameScene` component, which handles all 3D scene setup and UI elements.
+- **`GameSceneCanvas.tsx`** — R3F `Canvas` root. Declares `FlightControllerKeyMapping` (W/S throttle, A/D yaw, Arrows pitch/roll), hosts Rapier `Physics` (paused until `isMapPhysicsReady`), `FlightViewController`, `Sky`, ambient + `FollowLight`, and mounts `MapPhysicsReadyChecker`, `EffectContainer`, `Player`, `FloatingShapes`, `Ground`. Requests pointer lock on `pointerdown`.
+- **`MapPhysicsReadyChecker.tsx`** — downward raycast from `(0, 50, 0)` each frame; flips `isMapPhysicsReady` on the first non-sensor, non-Capsule hit or after 180 frames.
+- **`Player.tsx`** — wraps `RigidBodyPlayer` + `Aircraft`. Kinematic (no gravity, sensor), uses a manual `CuboidCollider`. Registers into `multiPlayerStore`, streams position and 5-frame averaged speed into `localPlayerStore`, fires bullets on `Space` with a 200 ms cooldown via `effectStore`, and resets pose on `R` (edge-triggered).
+- **`Aircraft.tsx`** — procedural plane mesh (body, wings, cockpit, tail, nose cone, propeller). Spins the propeller each frame (scaled by `localPlayerStore.state.speed` when `localPlayer` is true, otherwise fixed) and renders two `Trail`s off the wingtip targets.
+- **`FloatingShapes.tsx`** — spawns 150 kinematic `RigidBodyObject`s (balloon / bird / plane) across a 3000×3000 area between `y ≈ 100–400`, each with one of three motion types: `oscillate`, `circle`, `drift`.
+- **`Ground.tsx`** — world geometry and decor: a `SEA`-tagged plane (10000×10000), a `FLOOR`-tagged grass plane (1000×1000), a 6×1000 runway with 100 lane markings, and 500 randomly scattered decorative meshes (box / sphere / cone) that avoid the runway corridor.
+- **`EffectContainer.tsx`** — renders effects from `effectStore`. Dispatches `BULLET` to `BulletEffectController` (wires `owner` via `multiPlayerStore.getConnectedPlayerRef`) and `EXPLOSION` to `Explosion`; on bullet hit, spawns an explosion at the contact point (skipping self-hits).
 
-### `src/App.css`
+## `src/components/r3f/effects/`
 
-- Defines the main styles for the `App` component and its child UI elements.
+- **`Bullet.tsx`** — kinematic-velocity `RigidBodyObject` with a `BULLET` tag. Moves via `castRay` per frame for accurate fast-body hit detection, freezes for up to 3 frames on hit to let `onTriggerEnter` resolve, and fires `onHit` / `onComplete`.
+- **`BulletEffectController.tsx`** — deserializes config, offsets the start position forward by 1 unit, renders `Bullet` and an optional `MuzzleFlash`.
+- **`MuzzleFlash.tsx`** — short-lived cone-petal + inner-glow flash oriented along the fire direction; fades out over `duration`.
+- **`Explosion.tsx`** — two instanced particle clouds (white + grey) that expand from the hit point and fade out over 500 ms.
 
-### `src/index.css`
+## `src/components/scene/`
 
-- Defines global base styles, Tailwind CSS directives, fonts, etc., applied throughout the application.
+- **`GameScene.tsx`** — layout shell stitching `GameSceneCanvas` (3D) and `GameSceneUI` (DOM overlay). Contains performance warnings against holding state in this node.
 
-### `src/constants/`
+## `src/components/ui/` (DOM overlay)
 
-- Directory defining constant values used throughout the application.
-  - **`controls.ts`**: Defines settings that map keyboard inputs (WASD, arrow keys, etc.) to corresponding actions (movement, firing, etc.).
-  - **`aircraft.ts`**: Defines constant values related to the aircraft, such as speed, rotation limits, etc.
-  - **`rigidBodyObjectType.ts`**: Defines constant values for different types of rigid body objects used in physics simulation (player, enemy, wall, floor, sea, etc.).
-
-### `src/components/`
-
-- Directory managing React components categorized by function.
-
-  - **`r3f/`**: Contains 3D components related to React Three Fiber.
-
-    - **`Aircraft.tsx`**: Component handling the logic related to the player-controlled aircraft model (movement, rotation, bullet firing trigger).
-    - **`MapPhysicsReadyChecker.tsx`**: Component that checks if the map physics system is ready by performing raycasting from above downward to detect map geometry and ensures physics interactions are properly initialized before gameplay begins. Performs checks every frame until valid map geometry is detected, with a timeout after 180 frames to prevent infinite checking. Excludes Capsule shapes (likely characters/objects) and sensor colliders from the inspection.
-    - **`Player.tsx`**: Main player component that uses `RigidBodyPlayer` from `vibe-starter-3d` for physics-based player control. It handles player registration, bullet firing with cooldown, position tracking, and reset functionality. **Key feature**: Uses `onTriggerEnter` and `onTriggerExit` events to handle player interactions with other objects in the scene (collision detection, area triggers, etc.). The component includes a custom `CuboidCollider` for precise collision detection and wraps the `Aircraft` component for visual representation.
-    - **`Experience.tsx`**: Component that sets up the core 3D scene elements. Includes ambient lighting, Sky environment, Player, Ground, and FloatingShapes components.
-    - **`FloatingShapes.tsx`**: Component generating and managing various 3D shapes floating randomly in the scene.
-    - **`GameSceneCanvas.tsx`**: React Three Fiber Canvas component that renders the 3D game world with physics simulation and controller setup.
-    - **`Ground.tsx`**: Component defining and visually representing the ground plane, runway, and scattered objects in the 3D space. It includes a sea plane, grass ground, runway with markings, and randomly generated objects (boxes, spheres, cones) scattered across the terrain. Has physical properties for collision detection.
-    - **`EffectContainer.tsx`**: Container component managing and rendering various visual effects like bullet firing and hit effects.
-    - **`effects/`**: Directory containing specific visual effect components.
-      - **`Bullet.tsx`**: Component defining the visual representation and individual behavior (movement, collision detection) of bullets fired from the airplane.
-      - **`BulletEffectController.tsx`**: Controller component responsible for creating and managing bullet-related effects (e.g., firing, collision). (Potential for Object Pooling usage)
-      - **`MuzzleFlash.tsx`**: Component representing the muzzle flash effect.
-      - **`Explosion.tsx`**: Component creating explosion and smoke particle effects when bullets hit targets or objects.
-
-  - **`scene/`**: Contains components related to scene setup.
-
-    - **`GameScene.tsx`**: Main game scene component that serves as a layout container arranging the game UI and 3D Canvas. Contains critical performance warnings and guidelines to prevent re-rendering issues. Includes the `GameSceneCanvas` and `GameSceneUI` components in a proper layered structure where the Canvas renders the 3D world and UI components render as overlays.
-
-  - **`ui/`**: Contains UI components for the game interface.
-    - **`GameSceneUI.tsx`**: Component that manages UI overlays for the game scene.
-    - **`StatusDisplay.tsx`**: UI component displaying game state information (e.g., airplane speed, altitude) on the screen.
-    - **`LoadingScreen.tsx`**: Loading screen component displayed during game loading.
-
-### `src/stores/`
-
-- Directory containing state management logic (e.g., Zustand).
-  - **`effectStore.ts`**: Store for managing effect-related state (e.g., bullets, explosions).
-  - **`gameStore.ts`**: Store that manages the overall game state. Tracks and controls the readiness state of the map physics system (`isMapPhysicsReady`). This state is used to determine physics simulation pause/resume and loading screen display.
-  - **`localPlayerStore.ts`**: Store that manages the local player's state, such as position tracking and speed tracking.
-  - **`multiPlayerStore.ts`**: Store that manages multiple connected players' rigid body references for multiplayer functionality, including registration, unregistration, and retrieval of player references.
-
-### `src/types/`
-
-- Directory containing TypeScript type definitions.
-  - **`effect.ts`**: Defines effect-related types.
-  - **`index.ts`**: Exports types from the `types` directory.
-
-### `src/utils/`
-
-- Directory containing utility functions used across the application.
-  - **`effectUtils.ts`**: Contains utility functions specifically related to managing and calculating visual effects.
+- **`GameSceneUI.tsx`** — shows `LoadingScreen` while `isMapPhysicsReady` is `false`, otherwise `StatusDisplay`.
+- **`LoadingScreen.tsx`** — full-screen spinner; auto-wraps in `<Html center>` when rendered inside `Canvas`.
+- **`StatusDisplay.tsx`** — HUD overlay. Reads speed (km/h) and altitude (m) from `localPlayerStore` via `requestAnimationFrame`, HP and player count from `@agent8/gameserver` (`subscribeRoomMyState`, `subscribeRoomState`), and lists the control scheme.

--- a/basic-3d-freeview-multiplay/PROJECT/Context.md
+++ b/basic-3d-freeview-multiplay/PROJECT/Context.md
@@ -1,0 +1,29 @@
+# Context — basic-3d-freeview-multiplay
+
+## Project Overview
+
+Three.js + React Three Fiber scaffold for a third-person multiplayer sandbox wired to `@agent8/gameserver`. Nickname setup, room create/join, lobby character selection, and in-game networking (state sync, RTT ping, remote player interpolation) are all implemented. The local player runs on `FreeViewController` + `CharacterRenderer` and throttles transform updates to the server; `NetworkContainer` spawns a `RemotePlayer` per ready remote user and applies incoming state to a `NetworkObject` ref.
+
+## Tech Stack
+
+_Exact versions are in `package.json`._
+
+- **Rendering**: Three.js, `@react-three/fiber`, `@react-three/drei`
+- **Physics**: `@react-three/rapier`
+- **Character framework**: `vibe-starter-3d` (`FreeViewController`, `CharacterRenderer`, `NetworkObject`, `FollowLight`)
+- **Multiplayer**: `@agent8/gameserver`
+- **State**: Zustand
+- **Utilities**: `lodash` (throttle for network sync)
+- **Build / Lang**: Vite, TypeScript
+- **Styling**: Tailwind CSS
+
+## Critical Memory
+
+- The app flow is a state machine in `App.tsx`: connect → `NicknameSetup` → `RoomManager` → `LobbyRoom` → `GameScene`. `GameScene` mounts only when `roomState.gameStarted` and the local user's `isReady` are both true.
+- `networkSyncStore.setServer(server)` must run whenever the connection toggles; it owns the periodic `handlePing` loop and exposes `rtt` to `RTT.tsx`.
+- Local player transform is sent via `server.remoteFunction('updateMyState', …)` throttled to 100 ms with position/rotation dirty checks (see `Player.tsx`). Do not bypass the throttle.
+- `NetworkContainer` drives remote players imperatively: it creates a `React.RefObject<RemotePlayerHandle>` per remote account and calls `syncState(state, position, rotation)` on each `subscribeRoomAllUserStates` update — remote transforms must not be driven through React props.
+- Server-side remote functions relied on by the client: `joinRoom`, `leaveRoom`, `setCharacter`, `toggleReady`, `updateMyState`, `handlePing`.
+- Character model and animation URLs are loaded via the `src/assets.json` manifest.
+</content>
+</invoke>

--- a/basic-3d-freeview-multiplay/PROJECT/Requirements.md
+++ b/basic-3d-freeview-multiplay/PROJECT/Requirements.md
@@ -1,0 +1,22 @@
+# Requirements — basic-3d-freeview-multiplay
+
+## Coding Patterns
+
+- Screen routing lives in `App.tsx` as a top-level state machine — extend existing branches instead of introducing a parallel router.
+- Stores are concern-split (Zustand): `networkSyncStore` for server/RTT lifecycle, `playerStore` for local rigid-body refs — do not cross-write.
+- R3F goes under `components/r3f/`, DOM under `components/ui/` and `components/scene/`; `GameScene.tsx` stitches the Canvas and the HUD and must not render 3D outside the `Canvas` tree.
+- Local player state goes out through `server.remoteFunction('updateMyState', …)` with the existing throttle (100 ms) and dirty-check thresholds; do not send every frame.
+- Remote player transforms are applied imperatively through `RemotePlayerHandle.syncState` — do not convert them into React props.
+- Animation ids must come from `CharacterState` in `constants/character.ts`; keyboard bindings from `constants/controls.ts`.
+- Character / animation URLs are resolved via `src/assets.json`; new characters are added there and referenced by key.
+
+## Known Issues / Constraints
+
+- `hooks/useNetworkSync.ts` duplicates `networkSyncStore`'s ping logic and is not wired — pick one before building on it.
+- `types/effect.ts` (`EffectType`, `EffectData`, `ActiveEffect`, `EffectEventMessage`) is declared but no effect system is implemented yet.
+- `LobbyRoom.tsx` contains a fallback `Assets.characters['avatarsample_d_darkness.vrm']` that does not exist in `assets.json`; only reachable if selection logic regresses.
+- No physics-ready gate exists — `GameScene` mounts as soon as `gameStarted && isReady` is true, so maps must be ready to render immediately.
+- `FreeViewController` owns camera and movement; there is no local override layer for its keyboard bindings.
+- Pointer lock is requested on every `Canvas` `pointerdown` with no mobile guard.
+</content>
+</invoke>

--- a/basic-3d-freeview-multiplay/PROJECT/Status.md
+++ b/basic-3d-freeview-multiplay/PROJECT/Status.md
@@ -1,0 +1,27 @@
+# Status — basic-3d-freeview-multiplay
+
+## Implemented
+
+- Third-person free-view camera (`FreeViewController`) with pointer-lock capture on canvas click
+- Character animation set (idle, walk, run, jump, punch, hit, die) via `CharacterRenderer` + `AnimationConfigMap`
+- Local-player input + state machine in `Player.tsx` (keyboard → `PlayerInputs` → `CharacterState`)
+- Networking lifecycle in `App.tsx`: connect → nickname → room create/join → lobby → game
+- Room flow: `joinRoom`, `leaveRoom`, `setCharacter`, `toggleReady` remote functions
+- Character selection in `LobbyRoom` with live `CharacterPreview` (IDLE animation)
+- Local-player transform sync: throttled `updateMyState` (100 ms) with position (0.01 m) / rotation (0.01 rad) dirty checks
+- Remote-player rendering: `NetworkContainer` subscribes to room state and drives per-account `RemotePlayer` refs via `syncState`; nicknames shown as billboards
+- RTT measurement: periodic `handlePing` in `networkSyncStore`, 5-sample trimmed average surfaced by `RTT.tsx`
+- Scene lighting: ambient + `FollowLight` + sunset environment preset
+- Flat `Floor` with trimesh collider
+
+## Installed but not wired
+
+- `@react-three/postprocessing` — no effect pipeline mounted
+- `types/effect.ts` — effect message / enum types declared with no producer or consumer
+- `hooks/useNetworkSync.ts` — standalone RTT hook superseded by `networkSyncStore`, no caller
+- `action3`, `action4`, `magic` keyboard bindings — mapped in `controls.ts`, no handler
+- `UserState.stats` (`maxHp`, `currentHp`) — present in server init and type, not read by any client code
+- `melee_attack`, `aim`, `shoot`, `aim_run` animation URLs — listed in `assets.json`, not referenced by `CharacterState`
+- World geometry beyond a flat `Floor`
+</content>
+</invoke>

--- a/basic-3d-freeview-multiplay/PROJECT/Structure.md
+++ b/basic-3d-freeview-multiplay/PROJECT/Structure.md
@@ -1,106 +1,56 @@
-# Basic 3D Free View
+# Structure — basic-3d-freeview-multiplay
 
-## Project Summary
+## `src/main.tsx`, `src/App.tsx`
 
-This project is a 3D character controller with free view camera, built using Three.js and React Three Fiber. It features a player character that can be controlled with keyboard inputs in a 3D environment. The character supports various animations including idle, walking, running, jumping, punching, and hit reactions. The camera follows the character with a free-view perspective, allowing users to navigate through the 3D space. This project is intended for multi-player gameplay.
+Entry point and root component. `App` wires `@agent8/gameserver` via `useGameServer`, drives the screen state machine (nickname → room manager → lobby → game), feeds the active server into `networkSyncStore`, and subscribes to room + room-my-state to track `gameStarted`, `isReady`, and selected character.
 
-## Implementation Strategy
+## `src/App.css`, `src/index.css`
 
-This project uses a **Three.js-based 3D approach** because:
+Component styles and global base (Tailwind directives, fonts).
 
-- It requires real-time 3D character animation and control
-- Three.js provides efficient 3D rendering in web browsers
-- React Three Fiber simplifies integration with React components
-- The vibe-starter-3d library provides essential character rendering and animation tools
+## `src/assets.json`
 
-Key technologies:
+Asset manifest — character model URLs (15 presets) and animation URLs (idle, walk, run, jump, punch, melee_attack, aim, shoot, aim_run, hit, die).
 
-- Three.js for 3D rendering
-- React Three Fiber for React integration
-- @react-three/rapier for physics simulation
-- @react-three/drei for useful Three.js helpers
-- vibe-starter-3d for character rendering and animation
-- Tailwind CSS for styling
+## `src/constants/`
 
-## Implemented Features
+- **`character.ts`** — `CharacterState` animation-state ids (IDLE, WALK, RUN, JUMP, PUNCH, HIT, DIE) and `DEFAULT_HEIGHT` (1.6).
+- **`controls.ts`** — `keyboardMap` for `KeyboardControls` (WASD/arrows, Space jump, Shift run, 1–4 actions, E magic).
 
-- Keyboard-controlled character movement (WASD/Arrow keys)
-- Character animations (idle, walk, run, jump, punch, hit, die)
-- Free view camera that follows the character
-- Physics-based character movement with collision detection
-- Character state management system
-- 3D environment with floor
-- Directional and ambient lighting
-- Animation system with support for looping and one-shot animations
-- Character bounding box calculations
-- Pointer lock for immersive control
+## `src/types/`
 
-## File Structure Overview
+- **`user.ts`** — `UserState` (account, nickname, isReady, character, position, rotation, state, stats) shared with the server.
+- **`player.ts`** — `PlayerInputs` (movement/action booleans) and `PlayerRef` (exposes `boundingBox`).
+- **`effect.ts`** — `EffectType` enum and effect message shapes (declared, not yet used in runtime code).
+- **`index.ts`** — barrel re-exports.
 
-### `src/main.tsx`
+## `src/hooks/`
 
-- Entry point for the application.
-- Sets up React rendering and mounts the `App` component.
+- **`useNetworkSync.ts`** — standalone RTT ping hook. Present but unused; `App.tsx` uses `networkSyncStore` instead.
 
-### `src/App.tsx`
+## `src/stores/` (Zustand)
 
-- Main application component.
-- Sets up the Colyseus client and manages the room state (`RoomManager`) and the game scene (`GameScene`).
-- Handles routing or state-based rendering between nickname setup, lobby screen, and game screen.
+- **`networkSyncStore.ts`** — holds the `GameServer` reference, runs the periodic `handlePing` loop (3 s interval, 5-sample rolling average with high/low trimmed), exposes `rtt` for the HUD.
+- **`playerStore.ts`** — registry of local rigid-body refs keyed by account (`registerPlayerRef` / `unregisterPlayerRef` / `getPlayerRef`).
 
-### `src/App.css`
+## `src/components/r3f/` (inside `Canvas`)
 
-- Defines the main styles for the `App` component and its child UI elements.
+- **`Experience.tsx`** — scene content: ambient light, `FollowLight`, sunset `Environment`, `Floor`, and the local `Player` wrapped in `FreeViewController` at `targetHeight = 1.6`.
+- **`Player.tsx`** — local player. Reads keyboard inputs, runs a `usePlayerStates` transition function, animates via `CharacterRenderer` + `AnimationConfigMap`, and throttles `server.remoteFunction('updateMyState', …)` to 100 ms with position (0.01 m) / rotation (0.01 rad) dirty-check thresholds.
+- **`RemotePlayer.tsx`** — remote player. Built on `NetworkObject` with a `CapsuleCollider`; exposes a `RemotePlayerHandle` whose `syncState` is called imperatively by `NetworkContainer` to drive position/rotation/animation. Renders a billboarded nickname label.
+- **`NetworkContainer.tsx`** — subscribes to `subscribeRoomState` and `subscribeRoomAllUserStates`; maintains the map of ready remote users, owns one ref per remote account, and mounts a `RemotePlayer` per entry.
+- **`CharacterPreview.tsx`** — IDLE-only preview renderer for the lobby character-selection modal.
+- **`Floor.tsx`** — fixed-body trimesh ground plane (100 × 100).
 
-### `src/index.css`
+## `src/components/scene/`
 
-- Defines global base styles, Tailwind CSS directives, fonts, etc., applied throughout the application.
+- **`GameScene.tsx`** — in-game layout. Renders the Leave/RoomID/RTT HUD, the R3F `Canvas` (pointer-lock on click), `KeyboardControls`, `Physics`, then `Experience` + `NetworkContainer` under `Suspense`. Also mounts `StatsGl` for debugging.
+- **`NicknameSetup.tsx`** — first-screen form for entering a nickname.
+- **`RoomManager.tsx`** — create-room / join-by-id UI after nickname is set.
+- **`LobbyRoom.tsx`** — in-room screen: character list, `CharacterPreview` modal, ready toggle, participant list. Calls `setCharacter` and `toggleReady` remote functions.
 
-### `src/assets.json`
+## `src/components/ui/` (DOM overlay)
 
-- File for managing asset metadata. Includes character model and animation information.
-
-### `src/constants/`
-
-- Directory defining constant values used throughout the application.
-  - **`controls.ts`**: Defines settings that map keyboard inputs (WASD, arrow keys, etc.) to corresponding actions (movement, jump, etc.).
-  - **`character.ts`**: Defines character-related constants (animation states, speed, etc.).
-
-### `src/types/`
-
-- Directory defining TypeScript types used in the application (e.g., `PlayerState`, `PlayerInput`).
-
-### `src/hooks/`
-
-- Directory defining reusable React hooks (e.g., `useKeyboardControls`).
-
-### `src/stores/`
-
-- Directory containing state management logic (e.g., Zustand).
-  - **`playerStore.ts`**: Manages player-related state (nickname, selected character, etc.).
-  - **`roomStore.ts`**: Manages Colyseus Room related state (room info, player list, etc.).
-
-### `src/components/`
-
-- Directory managing React components categorized by function.
-
-  - **`r3f/`**: Contains 3D components related to React Three Fiber.
-
-    - **`Experience.tsx`**: Main component responsible for setting up the 3D environment. Includes lighting `ambientLight`, environmental elements `Environment`, the local player `Player` wrapped in `FreeViewController`, the floor `Floor`, and the `FollowLight` component that follows the player.
-    - **`Floor.tsx`**: Component defining and visually representing the ground plane in the 3D space. Has physical properties.
-    - **`Player.tsx`**: Component handling the logic related to the local player character model (movement, rotation, animation state management, input processing, and sending to the server).
-    - **`RemotePlayer.tsx`**: Component rendering remote player character models, animations, positions, etc., based on the state received from the server.
-    - **`NetworkContainer.tsx`**: Manages all remote player states received from the server and renders a `RemotePlayer` component for each remote player.
-    - **`CharacterPreview.tsx`**: Component for previewing character models, e.g., on the character selection screen.
-    - **`EffectContainer.tsx`**: Component managing and applying postprocessing effects (e.g., Bloom, SSR).
-    - **`effects/`**: Directory containing individual visual effect components (specific effect files can be added).
-
-  - **`scene/`**: Contains components related to 3D scene setup and game state.
-
-    - **`GameScene.tsx`**: Sets up the React Three Fiber `Canvas` component (implementing the Pointer Lock feature), utilizes `KeyboardControls` for handling keyboard inputs, configures the physics simulation using the `Physics` component from `@react-three/rapier`, includes the network container `NetworkContainer` and loads the `Experience` component with `Suspense` to initialize the 3D rendering environment.
-    - **`NicknameSetup.tsx`**: UI component where the user enters their nickname and selects a character.
-    - **`LobbyRoom.tsx`**: Component that joins the Colyseus lobby room, displays the list of available game rooms, and provides UI for creating/joining rooms.
-    - **`RoomManager.tsx`**: Component responsible for Colyseus Room connection and state management. Conditionally renders `NicknameSetup`, `LobbyRoom`, `GameScene`, etc., based on the connection status with the server.
-
-  - **`ui/`**: Contains general UI components.
-    - **`RTT.tsx`**: UI component for displaying Round Trip Time (network latency).
+- **`RTT.tsx`** — displays rolling-average ping pulled from `networkSyncStore`.
+</content>
+</invoke>

--- a/basic-3d-freeview/PROJECT/Context.md
+++ b/basic-3d-freeview/PROJECT/Context.md
@@ -1,0 +1,24 @@
+# Context — basic-3d-freeview
+
+## Project Overview
+
+Three.js + React Three Fiber scaffold with a physics-based third-person character controller and a free-orbit camera. Player runs on `RigidBodyPlayer` with a full humanoid animation set; camera follows via `FreeViewController`; map physics are gated by a raycast-based ready check. Zustand stores are pre-split for multiplayer, and `@agent8/gameserver` is installed but no networking is wired.
+
+## Tech Stack
+
+_Exact versions are in `package.json`._
+
+- **Rendering**: Three.js, `@react-three/fiber`, `@react-three/drei`
+- **Physics**: `@react-three/rapier`
+- **Character framework**: `vibe-starter-3d` (`FreeViewController`, `RigidBodyPlayer`, `CharacterRenderer`, `FollowLight`)
+- **Multiplayer (unwired)**: `@agent8/gameserver`
+- **State**: Zustand
+- **Build / Lang**: Vite, TypeScript
+- **Styling**: Tailwind CSS
+
+## Critical Memory
+
+- Player must be built on `RigidBodyPlayer` and camera on `FreeViewController`; the physics bootstrap depends on this pipeline.
+- Physics stay paused until `gameStore.isMapPhysicsReady` is `true`. `MapPhysicsReadyChecker` releases it via a downward raycast — new map geometry must be reachable by it.
+- Handle player collisions via `RigidBodyPlayer.onTriggerEnter` / `onTriggerExit`, switching on `RigidBodyObjectType` tags.
+- Character model and animation URLs are loaded via the `src/assets.json` manifest.

--- a/basic-3d-freeview/PROJECT/Requirements.md
+++ b/basic-3d-freeview/PROJECT/Requirements.md
@@ -1,0 +1,14 @@
+# Requirements — basic-3d-freeview
+
+## Coding Patterns
+
+- Stores are concern-split (Zustand): `gameStore`, `localPlayerStore`, `multiPlayerStore`, `playerActionStore` — do not cross-write.
+- R3F goes under `components/r3f/`, DOM under `components/ui/`; `GameScene.tsx` stitches them and must not render 3D directly.
+- Extend `Player.tsx` by adding animation states, not by forking.
+- No magic values — animation ids in `constants/character.ts`, rigid-body types in `constants/rigidBodyObjectType.ts`.
+
+## Known Issues / Constraints
+
+- `vibe-starter-3d` owns keyboard bindings; there is no local `controls.ts` override.
+- `MapPhysicsReadyChecker` has a 180-frame raycast timeout — very slow map loads may expire it.
+- Pointer lock is desktop-only (guarded by `IS_MOBILE`).

--- a/basic-3d-freeview/PROJECT/Status.md
+++ b/basic-3d-freeview/PROJECT/Status.md
@@ -1,0 +1,17 @@
+# Status — basic-3d-freeview
+
+## Implemented
+
+- Third-person free-view camera (`FreeViewController`)
+- Physics-based character controller (`RigidBodyPlayer`) with full humanoid animation set (idle, walk, run, jump, punch, kick, melee attack, cast, hit, dance, swim, die)
+- Combat action state machine (`playerActionStore`)
+- Physics-ready bootstrap (`MapPhysicsReadyChecker` + `LoadingScreen`)
+- Desktop input (keyboard + mouse + pointer lock) and mobile input (`nipplejs` joystick + action buttons)
+- Collision triggers via `RigidBodyPlayer.onTriggerEnter` / `onTriggerExit`
+- Scene lighting: ambient + `FollowLight` + sunset environment preset
+
+## Installed but not wired
+
+- `@agent8/gameserver` — no networking / session code
+- `@react-three/postprocessing` — no effect pipeline
+- World geometry — only a flat `Floor`

--- a/basic-3d-freeview/PROJECT/Structure.md
+++ b/basic-3d-freeview/PROJECT/Structure.md
@@ -1,101 +1,44 @@
-# Basic 3D Free View
+# Structure — basic-3d-freeview
 
-## Project Summary
+## `src/main.tsx`, `src/App.tsx`
 
-This project is a 3D character controller with free view camera, built using Three.js and React Three Fiber. It features a player character that can be controlled with keyboard inputs in a 3D environment. The character supports various animations including idle, walking, running, jumping, punching, kicking, melee attacks, casting, hit reactions, dancing, swimming, and death. The camera follows the character with a free-view perspective, allowing users to navigate through the 3D space. The project includes state management with Zustand, collision detection, and game server integration for multiplayer capabilities.
+Entry point and root component. `App` renders `GameScene` inside a full-viewport container.
 
-## Implementation Strategy
+## `src/App.css`, `src/index.css`
 
-This project uses a **Three.js-based 3D approach** because:
+Component styles and global base (Tailwind directives, fonts).
 
-- It requires real-time 3D character animation and control
-- Three.js provides efficient 3D rendering in web browsers
-- React Three Fiber simplifies integration with React components
-- The vibe-starter-3d library provides essential character rendering and animation tools
+## `src/assets.json`
 
-Key technologies:
+Asset manifest — character model and animation URLs.
 
-- Three.js for 3D rendering
-- React Three Fiber for React integration
-- @react-three/rapier for physics simulation
-- @react-three/drei for useful Three.js helpers
-- vibe-starter-3d for character rendering and animation
-- Zustand for state management
-- @agent8/gameserver for multiplayer game server integration
-- Tailwind CSS for styling
+## `src/constants/`
 
-## Implemented Features
+- **`character.ts`** — animation state ids (idle, walk, run, jump, punch, kick, melee attack, cast, hit, dance, swim, die).
+- **`rigidBodyObjectType.ts`** — rigid-body category enum (player, enemy, monster, wall, obstacle, item, bullet, floor, …).
 
-- Keyboard-controlled character movement (WASD/Arrow keys)
-- Extensive character animations (idle, walk, run, jump, punch, kick, melee attack, cast, hit, dance, swim, die)
-- Free view camera that follows the character
-- Physics-based character movement with collision detection
-- Advanced character state management system with Zustand
-- 3D environment with floor and environmental lighting
-- Directional and ambient lighting with sunset environment preset
-- Animation system with support for looping and one-shot animations
-- Character bounding box calculations
-- Pointer lock for immersive control
-- Collision trigger system using RigidBodyPlayer's onTriggerEnter/onTriggerExit events for object interactions
-- Game server integration for multiplayer support
-- Player reference management system
+> Keyboard bindings come from `vibe-starter-3d`'s `FreeViewController` defaults; no local `controls.ts` ships.
 
-## File Structure Overview
+## `src/stores/` (Zustand)
 
-### `src/main.tsx`
+- **`gameStore.ts`** — global lifecycle; holds `isMapPhysicsReady`.
+- **`localPlayerStore.ts`** — local-player state (position etc.).
+- **`multiPlayerStore.ts`** — registry of remote-player rigid-body refs.
+- **`playerActionStore.ts`** — combat action transitions (punch, kick, melee, cast).
 
-- Entry point for the application.
-- Sets up React rendering and mounts the `App` component.
+## `src/components/r3f/` (inside `Canvas`)
 
-### `src/App.tsx`
+- **`GameSceneCanvas.tsx`** — R3F `Canvas` root. Hosts Rapier `Physics` (paused until `isMapPhysicsReady`), `FreeViewController`, lighting (ambient + `FollowLight`), sunset `Environment`, and mounts `MapPhysicsReadyChecker`, `Player`, `Floor`. Requests desktop pointer-lock on `pointerdown`.
+- **`MapPhysicsReadyChecker.tsx`** — raycasts downward each frame to detect map geometry; flips `isMapPhysicsReady` on hit or after a 180-frame timeout. Ignores capsules and sensor colliders.
+- **`Player.tsx`** — wraps `RigidBodyPlayer` + `CharacterRenderer`; owns animation-state determination and trigger-based collision handling.
+- **`Floor.tsx`** — flat ground plane with a physics collider.
 
-- Main application component.
-- Configures the overall layout and includes the `GameScene` component.
+## `src/components/scene/`
 
-### `src/App.css`
+- **`GameScene.tsx`** — layout shell stitching `GameSceneCanvas` (3D) and `GameSceneUI` (DOM overlay). Contains performance-critical warnings against mixing concerns.
 
-- Defines the main styles for the `App` component and its child UI elements.
+## `src/components/ui/` (DOM overlay)
 
-### `src/index.css`
-
-- Defines global base styles, Tailwind CSS directives, fonts, etc., applied throughout the application.
-
-### `src/assets.json`
-
-- File for managing asset metadata. Includes character model and animation information.
-
-### `src/constants/`
-
-- Directory defining constant values used throughout the application.
-  - **`controls.ts`**: Defines settings that map keyboard inputs (WASD, arrow keys, etc.) to corresponding actions (movement, jump, etc.).
-  - **`character.ts`**: Defines character-related constants including extensive animation states (idle, walk, run, jump, punch, kick, melee attack, cast, hit, dance, swim, die).
-  - **`rigidBodyObjectType.ts`**: Defines constants for different types of rigid body objects in the physics simulation (player, enemy, monster, wall, obstacle, item, bullet, floor, etc.).
-
-### `src/stores/`
-
-- Directory containing state management stores using Zustand.
-  - **`gameStore.ts`**: Store that manages the overall game state. Tracks and controls the readiness state of the map physics system (`isMapPhysicsReady`). This state is used to determine physics simulation pause/resume and loading screen display.
-  - **`localPlayerStore.ts`**: Store that manages the local player's state, such as position tracking.
-  - **`multiPlayerStore.ts`**: Store that manages multiple connected players' rigid body references for multiplayer functionality, including registration, unregistration, and retrieval of player references.
-- **`playerActionStore.ts`**: Store that manages player action states including combat actions (punch, kick, meleeAttack, cast) with support for setting, getting, and resetting action states.
-
-### `src/components/`
-
-- Directory managing React components categorized by function.
-
-  - **`r3f/`**: Contains 3D components related to React Three Fiber.
-
-    - **`Experience.tsx`**: Simplified 3D scene component that focuses on core scene elements. Includes ambient lighting with 0.7 intensity, sunset environment preset (background disabled), the `Player` component, and the `Floor` component. This component has been streamlined to contain only essential scene elements.
-    - **`Floor.tsx`**: Component defining and visually representing the ground plane in the 3D space. Has physical properties.
-    - **`GameSceneCanvas.tsx`**: React Three Fiber Canvas component that renders the 3D game world with physics simulation and controller setup.
-    - **`MapPhysicsReadyChecker.tsx`**: Component that checks if the map physics system is ready by performing raycasting from above downward to detect map geometry and ensures physics interactions are properly initialized before gameplay begins. Performs checks every frame until valid map geometry is detected, with a timeout after 180 frames to prevent infinite checking. Excludes Capsule shapes (likely characters/objects) and sensor colliders from the inspection.
-    - **`Player.tsx`**: Advanced component built around the `RigidBodyPlayer` component from vibe-starter-3d for physics-based character control. Handles comprehensive player character logic including movement, rotation, extensive animation state management (idle, walk, run, jump, punch, kick, melee attack, cast, hit, dance, swim, die), collision detection, game server integration, and player reference management. Features sophisticated animation configuration mapping and state determination logic. Utilizes `RigidBodyPlayer`'s `onTriggerEnter` and `onTriggerExit` events to handle player interactions with other objects in the 3D environment, enabling collision-based gameplay mechanics. Integrates with `CharacterRenderer` for visual representation and animation playback.
-
-  - **`scene/`**: Contains components related to scene setup.
-
-    - **`GameScene.tsx`**: Main game scene component that serves as a layout container arranging the game UI and 3D Canvas. Contains critical performance warnings and guidelines to prevent re-rendering issues. Includes the `GameSceneCanvas` and `GameSceneUI` components in a proper layered structure where the Canvas renders the 3D world and UI components render as overlays.
-
-  - **`ui/`**: Contains UI components for the game interface.
-    - **`GameSceneUI.tsx`**: Component that manages UI overlays for the game scene.
-    - **`LoadingScreen.tsx`**: Loading screen component displayed during game loading.
-    - **`InputController.tsx`**: Manages all input handling including keyboard, mouse, and touch controls with virtual joystick support for mobile devices and action buttons for combat actions (punch, kick, melee attack, cast) and movement controls.
+- **`GameSceneUI.tsx`** — UI overlay container.
+- **`LoadingScreen.tsx`** — shown while `isMapPhysicsReady` is `false`.
+- **`InputController.tsx`** — keyboard / mouse / touch input, with `nipplejs` virtual joystick and action buttons on mobile.

--- a/basic-3d-minecraft-multiplay/PROJECT/Context.md
+++ b/basic-3d-minecraft-multiplay/PROJECT/Context.md
@@ -1,0 +1,29 @@
+# Context — basic-3d-minecraft-multiplay
+
+## Project Overview
+
+Three.js + React Three Fiber scaffold for a multiplayer voxel block game. A first-person player explores a procedurally generated Minecraft-style terrain built from instanced cubes and places new blocks via a center-screen raycast. Remote players, block state, and magic effects are synchronized through `@agent8/gameserver` (`joinRoom` → nickname + character select → ready → shared game scene). Terrain is generated once per room with `simplex-noise` using a deterministic `verse{roomId}` seed.
+
+## Tech Stack
+
+_Exact versions are in `package.json`._
+
+- **Rendering**: Three.js, `@react-three/fiber`, `@react-three/drei`
+- **Physics**: `@react-three/rapier`
+- **Character framework**: `vibe-starter-3d` (`FirstPersonViewController`, `CharacterRenderer`, `NetworkObject`)
+- **Multiplayer**: `@agent8/gameserver` (`useGameServer`, `useRoomState`, `useRoomAllUserStates`)
+- **Procedural terrain**: `simplex-noise` with a seeded Alea PRNG
+- **Post-processing**: `@react-three/postprocessing` (available; wired via `EffectContainer`)
+- **State**: Zustand
+- **Utilities**: `lodash` (throttle for network sync / raycast)
+- **Build / Lang**: Vite, TypeScript
+- **Styling**: Tailwind CSS
+
+## Critical Memory
+
+- Terrain is generated client-side from seed `verse${roomId}` in `NetworkContainer`, then pushed to the server via `initializeCubes`. Once populated, `room.cubes` is the source of truth and every client diffs it against `prevCubesRef` to add/remove cubes locally.
+- Local player input is throttled to the server at 100 ms via `updatePlayerTransform` (`lodash.throttle`). Position/rotation dirty checks gate the network call.
+- Block placement goes through `useCubeRaycaster` (screen-center `THREE.Raycaster`, `near`/`far` clamped). On left click it calls the server's `addCube` remote function; it does not write directly to `cubeStore`.
+- The InstancedMesh uses a custom shader (`uvOffsetScale` instanced attribute) to atlas-slice the Minecraft sprite sheet. Max instances = 1,000,000; chunks are 10³ with an active radius of 3.
+- Seed default comes from `VITE_AGENT8_VERSE` (see `dotenv`). Without it, `cubeStore` falls back to `'minecraft123'`.
+- Effects (`FIREBALL`, `EXPLOSION`) are added locally via `effectStore` and rebroadcast through `sendEffectEvent`; `EffectContainer` listens on `effect-event` room messages and replays remote casts.

--- a/basic-3d-minecraft-multiplay/PROJECT/Requirements.md
+++ b/basic-3d-minecraft-multiplay/PROJECT/Requirements.md
@@ -1,0 +1,20 @@
+# Requirements — basic-3d-minecraft-multiplay
+
+## Coding Patterns
+
+- Zustand stores are concern-split: `cubeStore` (world blocks + selected tile), `effectStore` (VFX queue), `networkSyncStore` (server handle + RTT). Do not cross-write.
+- R3F components go under `components/r3f/`, scene/lobby DOM screens under `components/scene/`, HUD overlays (`Crosshair`, `TileSelector`) directly under `components/`. `GameScene.tsx` composes them and must keep DOM overlays outside the `Canvas`.
+- Block mutations must go through the server: left-click → `useCubeRaycaster` → `server.remoteFunction('addCube', …)`; the local `cubeStore` is updated on the round-trip via `NetworkContainer`'s `subscribeRoomState` diff.
+- Terrain generation lives in `utils/terrainGenerator.ts` and is invoked exactly once per room, gated by `terrainInitializedRef` inside `NetworkContainer`. Seed must be `verse${roomId}` for determinism across clients.
+- All block ids come from `TILE_TYPES` in `terrainGenerator.ts`; all animation ids from `constants/character.ts`; all key bindings from `constants/controls.ts` (`keyboardMap`). No string literals for these.
+- Remote player transforms are applied via `RemotePlayerHandle.syncState` on refs kept in `NetworkContainer`, not by re-rendering on every state update.
+
+## Known Issues / Constraints
+
+- `InstancedCubes` disables its `TrimeshCollider` / per-cube `CuboidCollider` (commented out). Chunks create `RigidBody`s but no active colliders, so the player falls through stacked cubes and stands on `Floor` only. Re-enabling physics requires un-commenting and sizing the trimesh or cuboid colliders.
+- `Experience.tsx` renders `<Floor />` twice (inside and outside `KeyboardControls`). One of them is redundant.
+- `GameScene.tsx` mounts `<Physics debug={true}>`; the green debug wireframes are visible in-game.
+- `networkSyncStore.startSync`'s `sendPing` returns immediately (`return;` at the top), so RTT history never populates through this path. `useNetworkSync` is the working alternative but is not mounted.
+- `server.remoteFunction('addCube', …)` in `useCubeRaycaster` runs without a null check on `server`; clicking before the game-server context resolves will throw.
+- Seed falls back to the literal `'minecraft123'` when `VITE_AGENT8_VERSE` is unset — in that case all rooms on that deployment share identical terrain unless a verse id is provided.
+- `dotenv` is declared as a runtime dependency but Vite reads `.env` natively; the dependency is effectively unused at runtime.

--- a/basic-3d-minecraft-multiplay/PROJECT/Status.md
+++ b/basic-3d-minecraft-multiplay/PROJECT/Status.md
@@ -1,0 +1,24 @@
+# Status — basic-3d-minecraft-multiplay
+
+## Implemented
+
+- Connection flow: connecting spinner → nickname → room create/join → lobby (character + ready) → in-game scene, all driven by `@agent8/gameserver` hooks.
+- Multiplayer server bridge: `joinRoom`, `leaveRoom`, `toggleReady`, `setCharacter`, `updatePlayerTransform`, `addCube`, `initializeCubes`, `sendEffectEvent`, `handlePing` (in `server.js`).
+- Remote-player sync: per-account `RemotePlayer` refs, transform/state replication via `subscribeRoomAllUserStates`, billboarded nickname labels.
+- First-person controller (`FirstPersonViewController`) with humanoid animation set (idle, walk, run, jump, punch, hit, die) and a magic cast on `KeyE`.
+- Local-player network sync throttled at 100 ms with position/rotation dirty checks.
+- Procedural terrain: `simplex-noise` + Alea PRNG, seeded by `verse${roomId}`, 80×80 tiles, 25 block types, optional trees, water plane, sub-surface dirt/stone.
+- World reconciliation: `cubeStore` diffed against server `room.cubes` (initial full load, then per-key add/remove).
+- Instanced rendering: single `InstancedMesh` with a custom `uvOffsetScale` shader over the Minecraft sprite atlas; camera-chunked activation (10³ chunks, 3-chunk radius, up to 27 active).
+- Block placement: center-screen raycast (`useCubeRaycaster`) with a semi-transparent `CubePreview` and server-authoritative `addCube` round-trip.
+- Tile HUD: `TileSelector` carousel + `Q`/`E` hotkeys, `Crosshair` aiming reticle.
+- Lobby character preview (`CharacterPreview` inside a dedicated `Canvas`).
+- Magic VFX pipeline: `FireBallEffectController` + `Explosion`, local playback via `effectStore`, remote replay via `effect-event` room messages.
+
+## Installed but not wired
+
+- `@react-three/postprocessing` — dependency present; `EffectContainer` renders gameplay VFX but no post-processing pass is configured.
+- `useNetworkSync` hook — functional RTT sampler, not mounted. `networkSyncStore.startSync` exists but its `sendPing` is short-circuited.
+- `dotenv` — declared as a dependency; Vite handles `.env` directly, so it is not used at runtime.
+- Chunk colliders (`TrimeshCollider` / `CuboidCollider`) in `InstancedCubes.tsx` — code paths exist but are commented out, so cubes are not solid to the player.
+- `stats` / HP fields on `UserState` — populated at join but not consumed in gameplay.

--- a/basic-3d-minecraft-multiplay/PROJECT/Structure.md
+++ b/basic-3d-minecraft-multiplay/PROJECT/Structure.md
@@ -1,109 +1,71 @@
-# Basic 3D Free View
+# Structure — basic-3d-minecraft-multiplay
 
-## Project Summary
+## `src/main.tsx`, `src/App.tsx`
 
-This project is a 3D character controller with free view camera, built using Three.js and React Three Fiber. It features a player character that can be controlled with keyboard inputs in a 3D environment. The character supports various animations including idle, walking, running, jumping, punching, and hit reactions. The camera follows the character with a free-view perspective, allowing users to navigate through the 3D space. This project is intended for multi-player gameplay.
+Entry point and root component. `App` owns the connection state machine: not-connected spinner → `NicknameSetup` → `RoomManager` → `LobbyRoom` → `GameScene`. It bridges the `@agent8/gameserver` client into `networkSyncStore` and subscribes to `roomState.gameStarted` to decide when to enter the 3D scene.
 
-## Implementation Strategy
+## `src/App.css`, `src/index.css`
 
-This project uses a **Three.js-based 3D approach** because:
+Component styles and global base (Tailwind directives).
 
-- It requires real-time 3D character animation and control
-- Three.js provides efficient 3D rendering in web browsers
-- React Three Fiber simplifies integration with React components
-- The vibe-starter-3d library provides essential character rendering and animation tools
+## `src/assets.json`
 
-Key technologies:
+Asset manifest — character GLBs, mixamorig animations, and the `minecraft` sprite sheet (80×80 px, 16 px cells) used for block textures.
 
-- Three.js for 3D rendering
-- React Three Fiber for React integration
-- @react-three/rapier for physics simulation
-- @react-three/drei for useful Three.js helpers
-- vibe-starter-3d for character rendering and animation
-- Tailwind CSS for styling
+## `src/constants/`
 
-## Implemented Features
+- **`character.ts`** — animation state ids (`IDLE`, `WALK`, `RUN`, `JUMP`, `PUNCH`, `HIT`, `DIE`) and `DEFAULT_HEIGHT = 1.6`.
+- **`controls.ts`** — `keyboardMap` for `KeyboardControls` (WASD/arrows, `Space`, `Shift`, `1`–`4`, `KeyE` for magic).
 
-- Keyboard-controlled character movement (WASD/Arrow keys)
-- Character animations (idle, walk, run, jump, punch, hit, die)
-- Free view camera that follows the character
-- Physics-based character movement with collision detection
-- Character state management system
-- 3D environment with grid floor
-- Directional and ambient lighting
-- Animation system with support for looping and one-shot animations
-- Character bounding box calculations
-- Pointer lock for immersive control
+## `src/types/`
 
-## File Structure Overview
+- **`user.ts`** — `UserState` (nickname, character, transform, state, stats).
+- **`room.ts`** — `RoomState` (`gameStarted`, `cubes: Record<string, CubeInfo>`).
+- **`player.ts`** — `PlayerInputs`, `PlayerRef`.
+- **`effect.ts`** — `EffectType` enum (`FIREBALL`, `EXPLOSION`), `EffectData`, `ActiveEffect`.
+- **`index.ts`** — barrel re-export of `user` / `player` / `effect`.
 
-### `src/main.tsx`
+## `src/hooks/`
 
-- Entry point for the application.
-- Sets up React rendering and mounts the `App` component.
+- **`useCubeRaycaster.tsx`** — throttled (150 ms) screen-center raycast against the scene; filters for cubes / floor / chunk colliders; emits `previewPosition` and on left-click calls `server.remoteFunction('addCube', …)`.
+- **`useNetworkSync.ts`** — periodic `handlePing` RTT sampler with a rolling 3-value average. Installed but not currently mounted by any component.
 
-### `src/App.tsx`
+## `src/utils/`
 
-- Main application component.
-- Sets up the Colyseus client and manages the room state (`RoomManager`) and the game scene (`GameScene`).
-- Handles routing or state-based rendering between nickname setup, lobby screen, and game screen.
+- **`terrainGenerator.ts`** — `simplex-noise` + Alea PRNG. Exports `TILE_TYPES` (25 block ids), `generateTerrain(seed, width, depth)` that builds height map, water plane, surface tiles, sub-surface dirt/stone, and rare trees.
+- **`tileTextureLoader.ts`** — sprite-sheet-backed `TextureLoader` with per-tile UV cache; exposes `getSpriteInfo`, `getTileCoordinates`, `getTileTexture`, `getTotalTileCount`.
 
-### `src/App.css`
+## `src/store/` (Zustand)
 
-- Defines the main styles for the `App` component and its child UI elements.
+- **`cubeStore.ts`** — `cubes: CubeInfo[]`, `selectedTile`, `TERRAIN_CONFIG` (80×80), `DEFAULT_SEED` (from `VITE_AGENT8_VERSE`). CRUD actions `addCube` / `removeCube` / `updateCubes` / `regenerateTerrain`.
+- **`effectStore.ts`** — `activeEffects` list + `addEffect` / `removeEffect` with an auto-incrementing key.
+- **`networkSyncStore.ts`** — holds the `GameServer` reference and maintains a ping-based RTT rolling average (ping loop is currently inert — `sendPing` returns early).
 
-### `src/index.css`
+## `src/components/` (DOM overlay)
 
-- Defines global base styles, Tailwind CSS directives, fonts, etc., applied throughout the application.
+- **`Crosshair.tsx`** — fixed-center DOM crosshair for aiming block placement.
+- **`TileSelector.tsx`** — bottom-center 7-tile carousel backed by the sprite sheet; `Q`/`E` cycle selection and write to `cubeStore.selectedTile`.
 
-### `src/assets.json`
+## `src/components/scene/`
 
-- File for managing asset metadata. Includes character model and animation information.
+- **`NicknameSetup.tsx`** — nickname entry form.
+- **`RoomManager.tsx`** — create-new-room / join-by-id form.
+- **`LobbyRoom.tsx`** — character picker, ready toggle, participants list, and a side `Canvas` running `CharacterPreview` for the chosen model.
+- **`GameScene.tsx`** — active-game shell: full-viewport `Canvas` with `<Physics debug>`, `<Suspense>` wrapping `Experience` + `NetworkContainer` + `EffectContainer`; overlays `TileSelector`, `Crosshair`, leave button, and `StatsGl`. Requests pointer lock on `pointerdown`.
 
-### `src/vite-env.d.ts`
+## `src/components/r3f/` (inside `Canvas`)
 
-- Type definition file related to Vite.
+- **`Experience.tsx`** — local player stack. Mounts `KeyboardControls`, `Environment` (sunset), `FirstPersonViewController` wrapping `Player`, `Floor`, and the `CubePreview` anchored to `useCubeRaycaster().previewPosition`.
+- **`Player.tsx`** — local-player logic: keyboard polling, state-machine for `CharacterState`, throttled `updatePlayerTransform` sync, magic cast trigger (`KeyE` → `FIREBALL`), `CharacterRenderer` rendered invisibly (first-person).
+- **`Floor.tsx`** — wide `boxGeometry` ground plane with the dirt texture, `RigidBody type="fixed" colliders="cuboid"`, tagged `userData.isFloor = true` for the raycaster.
+- **`NetworkContainer.tsx`** — subscribes to `subscribeRoomAllUserStates` / `subscribeRoomState`; manages per-account `RemotePlayer` refs, bootstraps terrain on first empty-room load (`generateTerrain` → `initializeCubes`), and diffs `room.cubes` against `prevCubesRef` to reconcile `cubeStore`. Also mounts `InstancedCubes`.
+- **`RemotePlayer.tsx`** — `NetworkObject`-based remote character with capsule collider, animation map, and a billboarded nickname label. Exposes `syncState(state, position, rotation)` via ref.
+- **`InstancedCubes.tsx`** — the world. Camera-chunk tracker splits cubes into 10³ chunks, activates up to 27 chunks in a sphere of radius 3 around the camera, generates per-chunk trimesh/face data, and renders a single `InstancedMesh` with a custom `uvOffsetScale` shader against the sprite sheet. `onClick` adds a cube on the hit face (client-side fallback).
+- **`CubePreview.tsx`** — semi-transparent preview mesh positioned at `useCubeRaycaster`'s `previewPosition`; textured from the currently selected tile.
+- **`CharacterPreview.tsx`** — idle-only `CharacterRenderer` used by `LobbyRoom` for the character picker.
+- **`EffectContainer.tsx`** — renders `activeEffects` from `effectStore`; subscribes to `effect-event` room messages to mirror remote casts; handles fireball hits into `EXPLOSION` spawns.
+- **`effects/FireBallEffectController.tsx`**, **`effects/FireBall.tsx`**, **`effects/Explosion.tsx`** — projectile + impact VFX with lifetime + hit callbacks.
 
-### `src/constants/`
+## `server.js`
 
-- Directory defining constant values used throughout the application.
-  - **`controls.ts`**: Defines settings that map keyboard inputs (WASD, arrow keys, etc.) to corresponding actions (movement, jump, etc.).
-  - **`character.ts`**: Defines character-related constants (animation states, speed, etc.).
-
-### `src/types/`
-
-- Directory defining TypeScript types used in the application (e.g., `PlayerState`, `PlayerInput`).
-
-### `src/hooks/`
-
-- Directory defining reusable React hooks (e.g., `useKeyboardControls`).
-
-### `src/store/`
-
-- Directory containing state management logic (e.g., Zustand).
-  - **`playerStore.ts`**: Manages player-related state (nickname, selected character, etc.).
-  - **`roomStore.ts`**: Manages Colyseus Room related state (room info, player list, etc.).
-
-### `src/components/`
-
-- Directory managing React components categorized by function.
-
-  - **`r3f/`**: Contains 3D components related to React Three Fiber.
-
-    - **`Experience.tsx`**: Main component responsible for the primary 3D scene configuration. Includes lighting, environmental elements, the local player (`Player`), remote players (`NetworkContainer`), the floor (`Floor`), and manages physics engine settings.
-    - **`Floor.tsx`**: Component defining and visually representing the ground plane in the 3D space. Has physical properties.
-    - **`Player.tsx`**: Component handling the logic related to the local player character model (movement, rotation, animation state management, input processing, and sending to the server).
-    - **`RemotePlayer.tsx`**: Component rendering remote player character models, animations, positions, etc., based on the state received from the server.
-    - **`NetworkContainer.tsx`**: Manages all remote player states received from the server and renders a `RemotePlayer` component for each remote player.
-    - **`CharacterPreview.tsx`**: Component for previewing character models, e.g., on the character selection screen.
-    - **`EffectContainer.tsx`**: Component managing and applying postprocessing effects (e.g., Bloom, SSR).
-    - **`effects/`**: Directory containing individual visual effect components (specific effect files can be added).
-
-  - **`scene/`**: Contains components related to 3D scene setup and game state.
-
-    - **`GameScene.tsx`**: Sets up the React Three Fiber `Canvas` component, implements the Pointer Lock feature, and loads the `Experience` component using `Suspense` to initialize the 3D rendering environment. Can receive the Colyseus Room instance and pass it to `Experience`.
-    - **`NicknameSetup.tsx`**: UI component where the user enters their nickname and selects a character.
-    - **`LobbyRoom.tsx`**: Component that joins the Colyseus lobby room, displays the list of available game rooms, and provides UI for creating/joining rooms.
-    - **`RoomManager.tsx`**: Component responsible for Colyseus Room connection and state management. Conditionally renders `NicknameSetup`, `LobbyRoom`, `GameScene`, etc., based on the connection status with the server.
-
-  - **`ui/`**: Directory containing components related to the user interface (UI). (Currently empty)
+Verse room server: `joinRoom`, `leaveRoom`, `toggleReady`, `setCharacter`, `updatePlayerTransform`, `addCube`, `initializeCubes`, `sendEffectEvent`, `handlePing`.

--- a/basic-3d-minecraft/PROJECT/Context.md
+++ b/basic-3d-minecraft/PROJECT/Context.md
@@ -1,0 +1,28 @@
+# Context — basic-3d-minecraft
+
+## Project Overview
+
+Three.js + React Three Fiber scaffold for a voxel block world with first-person controls and physics. The world is rendered as a single `InstancedMesh` driven by a seeded `simplex-noise` height-map; active chunks around the camera are given per-chunk `TrimeshCollider` bodies for collision. A face-color custom shader replaces textures, and a screen-center raycaster produces a synced preview cube for placement. The player runs on `RigidBodyPlayer` + `FirstPersonViewController` with a full humanoid animation set. Asset preloading is handled by a dedicated `PreloadScene` before `GameScene` mounts. `@agent8/gameserver` is imported for `account` identity only — no networking is wired.
+
+## Tech Stack
+
+_Exact versions are in `package.json`._
+
+- **Rendering**: Three.js, `@react-three/fiber`, `@react-three/drei`
+- **Physics**: `@react-three/rapier`
+- **Character framework**: `vibe-starter-3d` (`FirstPersonViewController`, `RigidBodyPlayer`, `CharacterRenderer`, `FollowLight`)
+- **Terrain**: `simplex-noise` (seeded 2D/3D), `lodash` (throttle)
+- **Multiplayer (identity only)**: `@agent8/gameserver`
+- **State**: Zustand
+- **Build / Lang**: Vite, TypeScript
+- **Styling**: Tailwind CSS
+- **Mobile input**: `nipplejs`
+
+## Critical Memory
+
+- Blocks are rendered via a single `InstancedMesh` with a custom shader that reads six per-face color attributes (`colorTop/Bottom/Front/Back/Left/Right`). Do not switch to textures unless explicitly requested — color data lives in `ALL_CUBE_COLORS` in `utils/colorUtils.ts`.
+- Cube positions are integer-coordinate and centered on the origin; `CubePreview`, `useCubeRaycaster`, and `InstancedCube.handleCubeClick` must share the same `hit + normal` coordinate math, or preview and placement will desync.
+- Collision is chunk-based: the world is partitioned into `CHUNK_SIZE = 10` (X/Z only); only chunks within `ACTIVE_CHUNKS_RADIUS = 3` and capped at `MAX_ACTIVE_CHUNKS = 27` get a `TrimeshCollider` built from visible-face merging. New map geometry must fall inside this active set to be collidable.
+- Physics stay paused until `gameStore.isMapPhysicsReady` is `true`. `MapPhysicsReadyChecker` raycasts down from `(0, 50, 0)`; the world's surface must be reachable from there before the 180-frame timeout.
+- `Player` must be built on `RigidBodyPlayer` and the camera on `FirstPersonViewController`; the physics/animation pipeline depends on this pair.
+- Character model and animation URLs come from `src/assets.json` and are preloaded by `PreloadScene` before `GameScene` mounts.

--- a/basic-3d-minecraft/PROJECT/Requirements.md
+++ b/basic-3d-minecraft/PROJECT/Requirements.md
@@ -1,0 +1,25 @@
+# Requirements — basic-3d-minecraft
+
+## Coding Patterns
+
+- Stores are concern-split (Zustand): `gameStore`, `localPlayerStore`, `multiPlayerStore`, `cubeStore` — do not cross-write. `playerActionStore` is a module-singleton transient-flag object; treat it as write-on-press / read-in-frame only.
+- R3F goes under `components/r3f/`, DOM under `components/ui/`; `GameScene.tsx` stitches them and must not render 3D directly or hold React state (see the in-file warning — any re-render here re-renders the entire `Canvas`).
+- Extend `Player.tsx` by adding animation states to `animationConfigMap` and action transitions in `updatePlayerState` / `handleAnimationComplete`, not by forking the component.
+- No magic values: animation ids in `constants/character.ts`, rigid-body types in `constants/rigidBodyObjectType.ts`, block ids in `constants/tiles.ts`, groupings in `constants/themes.ts`.
+- All cube colors live in `ALL_CUBE_COLORS` (`utils/colorUtils.ts`) and are consumed by both `InstancedCube` (per-face buffer attributes) and `SingleCube` (per-face materials). Add a tile by adding an entry here and to `TILE_TYPES`, not by branching renderers.
+- Preview and placement share coordinate math: the `round(hit − normal·0.5) + round(normal)` recipe in `useCubeRaycaster` must stay in lockstep with `InstancedCube.handleCubeClick`'s neighbor-direction table.
+- Raycasts and scene traversals in `useFrame` should be throttled (`useCubeRaycaster` uses `lodash/throttle` at 150ms) — do not run them every frame.
+- New block meshes must expose `userData.isCube = true` (or `userData.isFloor = true` for ground) so the raycaster picks them up.
+- Input is centralized in `components/ui/InputController.tsx`; route new bindings through `CONTROL_KEY_MAPPING` / `ACTION_KEY_MAPPING` rather than adding ad-hoc listeners.
+- Terrain generation belongs in `utils/cubeMapGenerator.ts`; the `TODO`-marked scaffolds (`BIOMES`, `BIOME_MODIFIERS`, `STRUCTURES`, `generateCaves`, `postProcessCubeMap`) are the designated extension points.
+
+## Known Issues / Constraints
+
+- `InputController` maps `removeCube` to `KeyG` / `Mouse2` and `cubeStore` exposes `removeCube`, but `playerActionStore` has no `removeCube` flag and `useCubeRaycaster` never calls it — block removal is not wired end-to-end.
+- `@agent8/gameserver` is imported only for `account` identity in `Player.tsx`; there is no session, room, or state-sync code. `multiPlayerStore` stays local-only.
+- `@react-three/postprocessing` is installed but not imported anywhere — no effect pipeline ships.
+- `MAX_ACTIVE_CHUNKS = 27` caps physics chunks; cubes in farther chunks render but are not collidable. Placing cubes into unloaded chunks yields render-only blocks until the camera gets closer.
+- `Water` is a visual plane only (no collider). The player can pass through it.
+- `MapPhysicsReadyChecker` has a 180-frame raycast timeout fired from `(0, 50, 0)` — terrain whose surface is below `y ≈ -50` or outside that ray will only be released by the timeout fallback.
+- `InstancedCube` rebuilds chunk meshes and uploads six color buffer attributes for all cubes whenever `cubes` changes; very large worlds or rapid placements can spike CPU.
+- Pointer lock is desktop-only (guarded by `IS_MOBILE`).

--- a/basic-3d-minecraft/PROJECT/Status.md
+++ b/basic-3d-minecraft/PROJECT/Status.md
@@ -1,0 +1,26 @@
+# Status — basic-3d-minecraft
+
+## Implemented
+
+- First-person camera + character controller (`FirstPersonViewController` + `RigidBodyPlayer`) with full humanoid animation set (idle, idle-01, walk, run, fast-run, jump, punch, kick, melee attack, cast, hit, die)
+- Action state machine (`playerActionStore`) with `lockControls` / `unlockControls` around non-looping animations
+- Voxel world: single `InstancedMesh` (capacity 1,000,000) with a custom per-face-color shader and border effect
+- Chunk system: 2D X/Z chunking (`CHUNK_SIZE = 10`), camera-distance activation within `ACTIVE_CHUNKS_RADIUS = 3`, cap `MAX_ACTIVE_CHUNKS = 27`, per-chunk merged `TrimeshCollider` with internal-face culling
+- Seeded procedural terrain via `simplex-noise` (80×80, centered on origin) with bedrock / dirt / grass layering; regenerable with a new seed
+- Screen-center raycaster (`useCubeRaycaster`, throttled 150ms) with translucent `CubePreview` synced to integer placement coordinates
+- Block placement via `F` / `Mouse0` (rising-edge through `playerActionStore.addCube`) and via direct pointer click on the instanced mesh
+- Tile system: 25 block types (`TILE_TYPES`), 7 color themes (`THEMES`), `TileSelector` with live 3D preview, `Q`/`E` cycle, `T` theme toggle
+- Physics-ready bootstrap (`MapPhysicsReadyChecker` + `LoadingScreen`)
+- Asset preloader (`PreloadScene`) with per-extension loader dispatch and shared `LoadingManager` progress
+- Water plane (visual only) at `y = 10`
+- Desktop input (keyboard + mouse + pointer lock) and mobile input (`nipplejs` joystick + `ADD CUBE` / `JUMP` buttons)
+- Scene lighting: ambient + three directional lights + `FollowLight` + dawn `Environment`
+- Crosshair overlay
+
+## Installed but not wired
+
+- `@agent8/gameserver` — only `account` is read; no session, room, or networking
+- `@react-three/postprocessing` — no effect pipeline
+- `cubeStore.removeCube` + `removeCube` key bindings (`G` / `Mouse2`) — store action exists, keybindings exist, but `playerActionStore` has no `removeCube` flag and no consumer calls it
+- `cubeMapGenerator` extension scaffolds — `BIOMES`, `BIOME_MODIFIERS`, `STRUCTURES`, `getBiomeAt`, `generateStructure`, `generateCaves`, `postProcessCubeMap` are `TODO` stubs
+- `Water` has no physics collider

--- a/basic-3d-minecraft/PROJECT/Structure.md
+++ b/basic-3d-minecraft/PROJECT/Structure.md
@@ -1,183 +1,63 @@
-# Basic 3D Minecraft-Style Voxel Game
+# Structure — basic-3d-minecraft
 
-## Project Summary
+## `src/main.tsx`, `src/App.tsx`
 
-This project is a 3D Minecraft-inspired voxel game built with Three.js and React. It features color-based block rendering, block manipulation, and first-person exploration. Players can add and remove blocks with various colors, explore the world, and create structures using different themed blocks.
+Entry point and root component. `App` toggles between `PreloadScene` (while loading) and `GameScene` (after `onComplete`).
 
-## Implementation Strategy
+## `src/App.css`, `src/index.css`
 
-This project uses a **Color-Based 3D Three.js Voxel Optimization** approach because:
+Component styles and global base (Tailwind directives, fonts).
 
-- It requires efficient block-based world rendering
-- Three.js provides powerful 3D rendering capabilities in web browsers
-- React Three Fiber simplifies integration with React components
-- Instanced rendering allows for thousands of blocks with good performance
-- Chunk-based systems enable efficient world exploration
+## `src/assets.json`
 
-Key technologies:
+Asset manifest — character model, animation URLs, and sprite references. Consumed by `PreloadScene` and `Player`.
 
-- Three.js - 3D rendering
-- React Three Fiber - React integration
-- @react-three/rapier - Physics simulation
-- Zustand - State management
-- vibe-starter-3d (v0.4.0) - Advanced character control, animation system, and physics integration
-- Instanced Meshes - Optimized block rendering
-- Custom Shaders - Face-specific coloring
-- Tailwind CSS - UI composition
+## `src/constants/`
 
-## Core Features
+- **`character.ts`** — animation state ids (idle, idle-01, walk, run, fast-run, jump, punch, kick, melee attack, cast, hit, die).
+- **`rigidBodyObjectType.ts`** — rigid-body category enum (local player, enemy, monster, wall, obstacle, item, bullet, floor, plotting board).
+- **`tiles.ts`** — `TILE_TYPES` enum of 25 block types (grass, dirt, stone, ores, wood, leaves, glass, wool, flowers, mushrooms, metal blocks, …).
+- **`themes.ts`** — `THEMES` enum + tile index groupings (`ALL`, `BLUE`, `GREEN`, `BROWN`, `GRAY`, `GOLD`, `RED`) with names, descriptions, icons, and lookup helpers.
 
-- **Block Manipulation**: Interactive block placing and removing with precise mouse targeting
-- **First-Person Control**: Smooth character movement with physics-based collision detection
-- **Advanced Animation System**: Character state management with multiple animation types (idle, walk, run, jump, cast)
-- **Color-Based Block System**: Multiple block types organized by intuitive color themes
-- **Optimized Rendering**: Chunk-based system with instanced meshes for efficient rendering of thousands of blocks
-- **Custom Shader Implementation**: Per-face color rendering without texture overhead
-- **Precise Raycasting**: Accurate block targeting with synchronized preview and placement systems
-- **Dynamic World Loading**: Automatic chunk loading/unloading based on player proximity
-- **Procedural CubeMap**: Advanced cubeMap generation with layer-based block distribution using absolute Y-coordinates
-- **Physics Integration**: Complete physics simulation with collision detection and rigid body management
-- **Player Reference System**: Multiplayer-ready player tracking and state management
+> Movement/jump/run key bindings are defined locally in `components/ui/InputController.tsx` (`CONTROL_KEY_MAPPING`); block-action bindings in `ACTION_KEY_MAPPING`.
 
-## Current Implementation Features
+## `src/stores/` (Zustand)
 
-- **Advanced Player System**: Dedicated Player.tsx component with comprehensive character management, animation control, and state transitions
-- **Character Animation System**: Complete character state management with animation mapping for idle, walking, running, jumping, and casting actions
-- **Physics Integration**: Full physics integration with collision detection, rigid body object type definitions, and player reference management
-- **Optimized CubeMap Generation**: Procedural cubeMap generation with smooth transitions, natural formations, and absolute Y-coordinate based layer distribution
-- **Precise Block Interaction**: Synchronized raycasting system with perfect alignment between preview and actual cube placement
-- **Theme-Based Block System**: Intuitive color-based theme organization with enhanced tile selection UI and visual feedback
-- **Chunk-Based Rendering**: Efficient world rendering with dynamic loading/unloading based on player proximity
-- **Custom Shader System**: Per-face color implementation for diverse block types without texture overhead
+- **`gameStore.ts`** — global lifecycle; holds `isMapPhysicsReady`.
+- **`localPlayerStore.ts`** — local-player position/speed (mutated in place to avoid per-frame subscriber churn).
+- **`multiPlayerStore.ts`** — registry of connected-player rigid-body refs, keyed by `account`.
+- **`cubeStore.ts`** — voxel world state: `cubes[]`, `seed`, `selectedTile`, `selectedTheme`, `availableTiles`, plus `addCube`, `removeCube`, `regenerateCubeMap`, theme switching. Seeds the initial world via `createInitialCubeMap` → `generateCubeMap` at 80×80.
+- **`playerActionStore.ts`** — transient action flags (`punch`, `kick`, `meleeAttack`, `cast`, `addCube`). Plain module-singleton object (not a Zustand store despite the filename).
 
-## Color System Design
+## `src/utils/`
 
-The rendering system uses a color-based approach with these key features:
+- **`colorUtils.ts`** — `ALL_CUBE_COLORS` table (per-tile × 6 faces RGB), `FACE_INDEX` map, and `getColorByFace` / `getTileTypeFromIndex` / `getThreeColor` helpers. Central color source for both `InstancedCube` shader attributes and `SingleCube` materials.
+- **`cubeMapGenerator.ts`** — seeded `simplex-noise` terrain generator. Exports `generateCubeMap`, plus scaffolds (`BIOMES`, `CUBEMAP_CONFIG`, `BIOME_MODIFIERS`, `STRUCTURES`, `getBiomeAt`, `generateStructure`, `generateCaves`, `postProcessCubeMap`) marked as `TODO` for extension.
 
-- Direct color values instead of textures for each cube face
-- Theme classifications organized by color-based themes (BLUE, GREEN, BROWN, GRAY, GOLD, RED)
-- Colors within each theme arranged as gradients from light to dark shades
-- Central color management system (ALL_CUBE_COLORS in colorUtils.ts) defines colors for all six faces of each cube type
-- Cleaner, more intuitive color management approach with consistent naming and organization
+## `src/hooks/`
 
-## File Structure Overview
+- **`useCubeRaycaster.tsx`** — screen-center raycaster (throttled to 150ms via lodash) against cube / floor meshes. Computes integer preview position from hit point + face normal using the same math as `InstancedCube.handleCubeClick`. On rising edge of `playerActionStore.addCube`, places a cube at the preview.
 
-### `src/main.tsx`
+## `src/components/r3f/` (inside `Canvas`)
 
-- Entry point for the application.
-- Sets up React rendering and mounts the `App` component.
+- **`GameSceneCanvas.tsx`** — R3F `Canvas` root. Hosts Rapier `Physics` (paused until `isMapPhysicsReady`), `FirstPersonViewController`, `FollowLight`, and mounts `MapPhysicsReadyChecker` and `Experience`. Requests desktop pointer-lock on `pointerdown`.
+- **`Experience.tsx`** — 3D scene composition: ambient + three `directionalLight`s, `Environment preset="dawn"`, `Water`, `InstancedCube`, `CubePreview` (driven by `useCubeRaycaster`), `Player`.
+- **`MapPhysicsReadyChecker.tsx`** — raycasts downward from `(0, 50, 0)` each frame; flips `isMapPhysicsReady` on first non-sensor, non-capsule hit or after a 180-frame timeout.
+- **`Player.tsx`** — wraps `RigidBodyPlayer` + `CharacterRenderer`; owns the full `animationConfigMap`, converts `CharacterMovementState` from `useControllerStore` to `CharacterState`, and routes action flags (`punch`/`kick`/`meleeAttack`/`cast`) through `lockControls` → `handleAnimationComplete` → `unlockControls`. Registers its rigid-body ref in `multiPlayerStore` by `account` and streams position into `localPlayerStore`.
+- **`InstancedCube.tsx`** — core voxel renderer. One `InstancedMesh` (capacity 1,000,000) with a custom vertex/fragment shader that applies per-face colors and a border effect. Partitions cubes into 2D chunks (X/Z, `CHUNK_SIZE = 10`), activates chunks within `ACTIVE_CHUNKS_RADIUS = 3` sorted by distance (cap `MAX_ACTIVE_CHUNKS = 27`), and for each active chunk builds merged vertex/index buffers with internal faces culled and mounts a `TrimeshCollider`. Click handler adds a neighbor cube in the clicked face's direction.
+- **`SingleCube.tsx`** — six-plane cube for UI / preview, reusing `ALL_CUBE_COLORS`. Supports `opacity < 1` translucent preview mode (basic material) and opaque mode (standard material).
+- **`CubePreview.tsx`** — positions a translucent `SingleCube` at the integer preview coordinate from `useCubeRaycaster`, scaled 1.03× to avoid z-fighting.
+- **`Water.tsx`** — a single 1000×1000 translucent plane at `y = 10` (semi-transparent blue); has `userData.type: 'fixed'` but no physics collider.
 
-### `src/App.tsx`
+## `src/components/scene/`
 
-- Main application component.
-- Configures the overall layout and includes the `GameScene` component.
-- Manages loading state and switches between `PreloadScene` and `GameScene`.
+- **`GameScene.tsx`** — layout shell stitching `GameSceneCanvas` (3D) and `GameSceneUI` (DOM overlay). Contains performance-critical warnings against mixing concerns.
+- **`PreloadScene.tsx`** — iterates every category in `assets.json` and loads each URL with the appropriate loader (GLTF / texture / audio / video / fetch) through a shared `LoadingManager`; renders a progress bar and calls `onComplete` when done.
 
-### `src/App.css`
+## `src/components/ui/` (DOM overlay)
 
-- Defines the main styles for the `App` component and its child UI elements.
-
-### `src/index.css`
-
-- Defines global base styles, Tailwind CSS directives, fonts, etc., applied throughout the application.
-
-### `src/stores/`
-
-- Directory containing state management stores using Zustand.
-  - **`gameStore.ts`**: Store that manages the overall game state. Tracks and controls the readiness state of the map physics system (`isMapPhysicsReady`). This state is used to determine physics simulation pause/resume and loading screen display.
-  - **`localPlayerStore.ts`**: Store that manages the local player's state, such as position tracking.
-  - **`multiPlayerStore.ts`**: Store that manages multiple connected players' rigid body references for multiplayer functionality, including registration, unregistration, and retrieval of player references.
-  - **`cubeStore.ts`**: Store for voxel world management that handles adding, removing, and storing block data. Also manages theme selection and controls selected block type.
-  - **`playerActionStore.ts`**: Store that manages player action states including combat actions (punch, kick, meleeAttack, cast) and block manipulation (addCube) with support for setting, getting, and resetting action states.
-
-### `src/utils/`
-
-- Directory containing utility functions for the game.
-  - **`colorUtils.ts`**: Defines and manages per-face colors for all block types and provides functions for color conversion and access.
-  - **`cubeMapGenerator.ts`**: Implements procedural cubeMap generation with multiple layers, using absolute Y-coordinates for consistent block distribution.
-
-### `src/hooks/`
-
-- Directory containing custom React hooks.
-  - **`useCubeRaycaster.tsx`**: Custom hook for block placement and removal. Implements precise raycasting for block targeting and handles mouse interactions with perfect alignment between preview and actual placement.
-
-### `src/constants/`
-
-- Directory defining constant values used throughout the application.
-  - **`controls.ts`**: Defines keyboard control mappings and sets up input configuration for character movement.
-  - **`tiles.ts`**: Defines tile types used throughout the application.
-  - **`themes.ts`**: Defines color themes and theme-based block groupings for intuitive selection.
-  - **`character.ts`**: Defines character animation states and types for player state management.
-  - **`rigidBodyObjectType.ts`**: Defines physics object types for collision detection and interaction systems.
-
-### `src/components/`
-
-- Directory managing React components.
-
-  - **`r3f/`**: Contains 3D components related to React Three Fiber.
-
-    - **`Experience.tsx`**: Sets up 3D environment including lighting, sky, and world elements. Coordinates the overall 3D scene composition.
-    - **`GameSceneCanvas.tsx`**: React Three Fiber Canvas component that renders the 3D game world with physics simulation and controller setup.
-    - **`MapPhysicsReadyChecker.tsx`**: Component that checks if the map physics system is ready by performing raycasting from above downward to detect map geometry and ensures physics interactions are properly initialized before gameplay begins. Performs checks every frame until valid map geometry is detected, with a timeout after 180 frames to prevent infinite checking. Excludes Capsule shapes (likely characters/objects) and sensor colliders from the inspection.
-    - **`Player.tsx`**: Advanced player component integrating RigidBodyPlayer with CharacterRenderer for comprehensive character management, physics interactions, and animation state management with collision detection capabilities.
-    - **`InstancedCube.tsx`**: Core voxel rendering system using instanced meshes with custom shader for optimized color-based rendering and chunk-based optimization.
-    - **`SingleCube.tsx`**: Component for rendering individual cubes with color-based faces for UI and preview purposes.
-    - **`CubePreview.tsx`**: Shows preview of block placement location with precise coordinate alignment to the actual placement position.
-    - **`Water.tsx`**: Implements water simulation with translucent rendering.
-
-  - **`scene/`**: Contains components related to scene setup.
-
-    - **`GameScene.tsx`**: Main game scene component that serves as a layout container arranging the game UI and 3D Canvas. Contains critical performance warnings and guidelines to prevent re-rendering issues. Includes the `GameSceneCanvas` and `GameSceneUI` components in a proper layered structure where the Canvas renders the 3D world and UI components render as overlays.
-    - **`PreloadScene.tsx`**: Manages asset preloading before the game starts and displays a loading progress bar.
-
-  - **`ui/`**: Contains UI components for the game interface.
-    - **`GameSceneUI.tsx`**: Component that manages UI overlays for the game scene.
-    - **`LoadingScreen.tsx`**: Loading screen component displayed during game loading.
-    - **`InputController.tsx`**: Manages all input handling including keyboard, mouse, and touch controls with virtual joystick support for mobile devices and action buttons for block manipulation.
-    - **`Crosshair.tsx`**: Displays a crosshair in the center of the screen for accurate block targeting.
-    - **`TileSelector.tsx`**: Provides UI for selecting different block types and themes with 3D preview of each block.
-
-### Key Libraries & Components from External Sources
-
-- **`vibe-starter-3d`**: A library providing foundational 3D game components and utilities.
-
-  - **`FirstPersonViewController`**: Implements a first-person camera and character controller with physics. Handles movement, looking, and interactions with the voxel world.
-  - **`FollowLight`**: A directional light that follows the character to ensure consistent lighting throughout the voxel world.
-
-- **`@react-three/rapier`**: Physics library for React Three Fiber.
-  - Provides collision detection essential for character movement and interaction with blocks
-  - Implements raycasting functionality used for block targeting and manipulation
-
-### Voxel System Implementation
-
-The Minecraft-style voxel system is implemented through a combination of components and techniques:
-
-1. **Chunk-Based Rendering**: The world is divided into chunks that are rendered using instanced meshes for performance optimization. Only chunks near the player are loaded, allowing for efficient rendering of large worlds.
-
-2. **Block Manipulation**: The system allows players to add and remove blocks through raycasting, with visual feedback provided through the `CubePreview` component which aligns perfectly with actual placement positions.
-
-3. **Color-Based System**: Multiple block types are supported through a custom shader that applies unique colors to each face, allowing for diverse environments with minimal performance impact.
-
-4. **Advanced Player System**: The dedicated `Player` component integrates with vibe-starter-3d's `FirstPersonViewController` and `CharacterRenderer` to provide smooth first-person movement, camera control, and comprehensive animation system with state management for character actions.
-
-5. **State Management**: Zustand stores including `cubeStore` for voxel world management and `playerStore` for player reference tracking maintain comprehensive game state, handling block operations, player physics interactions, and multiplayer support in a performant way.
-
-6. **Theme System**: Color-based themes group similar colored blocks to make it easy to create structures with natural gradient effects.
-
-7. **Optimized Instance Rendering**: The custom shader and instanced mesh approach allows for efficient rendering of thousands of blocks while still applying unique colors to each face of every block.
-
-8. **Advanced CubeMap Generation**: The cubeMap is generated using a layered approach based on absolute Y-coordinates, creating natural-looking landscapes with appropriate block types at different heights.
-
-9. **Coordinate System Synchronization**: The raycasting and placement systems are carefully aligned to ensure that preview blocks appear exactly where they will be placed, making building more intuitive and precise.
-
-# Critical Memory
-
-- **Design Decision**: Use only color values for cubes instead of textures if not explicitly requested
-
-# Next Actions
-
-- **HIGHEST PRIORITY**: AI AGENT MUST IMPLEMENT CREATIVE CUBEMAP GENERATION LOGIC IMMEDIATELY. Focus on cubeMapGenerator.ts and create an impressive, varied 3D world with multiple biomes, structures, and cubeMap features. This is the most critical task for game engagement and visual appeal. Skip all other tasks until cubeMap generation is complete and visually stunning.
-
-- **SECOND PRIORITY**: AI AGENT MUST IMPLEMENT SKYBOX USING EXISTING RESOURCES AND TOOLS. Immediately utilize available skybox resources, textures, or libraries to enhance the visual environment. If suitable tools or libraries exist for skybox implementation, use them directly rather than building from scratch. The skybox should complement the cubeMap features and biomes to create a cohesive visual experience. This task should be completed efficiently using readily available resources.
-
-- **Third Priority**: AI AGENT to implement additional gameplay features after cubeMap and skybox are properly implemented.
+- **`GameSceneUI.tsx`** — UI overlay container. Mounts `InputController`, `LoadingScreen` (while `isMapPhysicsReady` is `false`), `TileSelector`, `Crosshair`.
+- **`LoadingScreen.tsx`** — in-canvas-aware overlay (uses `drei` `Html` when inside a `Canvas`, plain DOM otherwise).
+- **`InputController.tsx`** — unified keyboard / mouse / touch input. Defines `CONTROL_KEY_MAPPING` (forward/backward/left/right/jump/run) and `ACTION_KEY_MAPPING` (`addCube: F/Mouse0`, `removeCube: G/Mouse2`). Drives `useInputStore` movement with analog intensity (walk / run boost / max), and `playerActionStore` for actions. Mobile: `nipplejs` joystick on the left half + on-screen `ADD CUBE` / `JUMP` buttons.
+- **`Crosshair.tsx`** — fixed screen-center crosshair overlay.
+- **`TileSelector.tsx`** — bottom-center tile picker with a live 3D `SingleCube` preview per slot. `Q`/`E` cycles tiles within the current theme, `T` toggles a theme picker (`Escape`/`T` to close). Regenerate button calls `cubeStore.regenerateCubeMap(seed)`.

--- a/basic-3d-quarterview-multiplay/PROJECT/Context.md
+++ b/basic-3d-quarterview-multiplay/PROJECT/Context.md
@@ -1,0 +1,28 @@
+# Context — basic-3d-quarterview-multiplay
+
+## Project Overview
+
+Three.js + React Three Fiber scaffold for a quarter-view 3D multiplayer game. A nickname + lobby flow (`NicknameSetup` → `RoomManager` → `LobbyRoom` → `GameScene`) drives users into a shared room where a local `Player` runs on `RigidBodyPlayer` and remote participants render as `RemotePlayer` via `NetworkContainer`. Camera is fixed to `QuarterViewController` with character-follow. `@agent8/gameserver` is fully wired: room join/leave, character selection, ready toggle, per-frame state sync (position/rotation/animation), HP/damage, and RTT ping. Server logic lives in `server.js`.
+
+## Tech Stack
+
+_Exact versions are in `package.json`._
+
+- **Rendering**: Three.js, `@react-three/fiber`, `@react-three/drei`
+- **Physics**: `@react-three/rapier`
+- **Character framework**: `vibe-starter-3d` (`QuarterViewController`, `RigidBodyPlayer`, `CharacterRenderer`, `NetworkObject`, `FollowLight`)
+- **Multiplayer**: `@agent8/gameserver` (wired)
+- **State**: Zustand
+- **Build / Lang**: Vite, TypeScript
+- **Styling**: Tailwind CSS
+
+## Critical Memory
+
+- Local player must be built on `RigidBodyPlayer`; remote players must be built on `NetworkObject` — do not swap these.
+- Physics stay paused until `gameStore.isMapPhysicsReady` is `true`. `MapPhysicsReadyChecker` releases it via a downward raycast — new map geometry must be reachable by it. `QuarterViewController` is mounted only after the gate opens.
+- Server communication is centralized: `networkSyncStore.setServer(server)` is called once in `App.tsx`; do not call `remoteFunction` without going through the existing flow (`updateMyState`, `joinRoom`, `leaveRoom`, `toggleReady`, `setCharacter`, `handlePing`, `revive`, `applyDamage`).
+- Local `Player` state sync is throttled (100 ms) and dirty-checked against position (0.01 m) / rotation (0.01 rad) thresholds — preserve these to avoid flooding the server.
+- `RemotePlayer` transforms arrive through `ref.syncState(...)`; never bypass `NetworkContainer` and render `RemotePlayer` directly.
+- Character model and animation URLs are loaded via the `src/assets.json` manifest; selected character key is stored in `UserState.character`.
+</content>
+</invoke>

--- a/basic-3d-quarterview-multiplay/PROJECT/Requirements.md
+++ b/basic-3d-quarterview-multiplay/PROJECT/Requirements.md
@@ -1,0 +1,22 @@
+# Requirements — basic-3d-quarterview-multiplay
+
+## Coding Patterns
+
+- Stores are concern-split (Zustand): `gameStore` (physics gate), `playerStore` (rigid-body registry), `networkSyncStore` (server handle + RTT) — do not cross-write.
+- R3F goes under `components/r3f/`; DOM goes under `components/ui/`; screen-level flow components live in `components/scene/`. `GameScene.tsx` stitches DOM + `Canvas` and must not render flow screens itself.
+- Extend `Player.tsx` by adding animation states and inputs; keep server calls inside the existing throttled `syncToNetwork` path.
+- Route all remote-player rendering through `NetworkContainer` — do not instantiate `RemotePlayer` elsewhere.
+- Use `networkSyncStore.setServer(server)` only in `App.tsx`; other components should consume the store.
+- No magic values — animation ids in `constants/character.ts`, rigid-body types in `constants/rigidBodyObjectType.ts`, keyboard bindings in `constants/controls.ts`.
+- Server methods (`joinRoom`, `leaveRoom`, `setCharacter`, `toggleReady`, `updateMyState`, `revive`, `handlePing`, `applyDamage`) are the only allowed entry points — extend `server.js` rather than inventing ad-hoc channels.
+
+## Known Issues / Constraints
+
+- `Experience.tsx` imports `FirstPersonViewController` from `vibe-starter-3d` but never uses it; the active camera is `QuarterViewController` mounted in `GameScene.tsx`.
+- `MapPhysicsReadyChecker` has a 180-frame raycast timeout — very slow map loads may expire it and force-release physics early.
+- Local player network sync is capped at ~10 Hz (`INTERVAL_MS: 100`) with position threshold 0.01 m and rotation threshold 0.01 rad; tightening these raises server load, loosening them causes visible lag on remote clients.
+- `RemotePlayer.syncState` is driven by `subscribeRoomAllUserStates`; the capsule collider uses `KINEMATIC_KINEMATIC` active collision types, so solid collisions against remote players are not simulated.
+- `LobbyRoom` falls back to `Assets.characters['avatarsample_d_darkness.vrm']` if a selected key is missing — that key is not in `assets.json`, so the fallback will crash. Always pick from the listed keys.
+- Ready flow is one-way: `toggleReady` also starts the room's `gameStarted` flag the first time any user readies up; there is no separate "start game" host action.
+</content>
+</invoke>

--- a/basic-3d-quarterview-multiplay/PROJECT/Status.md
+++ b/basic-3d-quarterview-multiplay/PROJECT/Status.md
@@ -1,0 +1,26 @@
+# Status — basic-3d-quarterview-multiplay
+
+## Implemented
+
+- Connection + lobby flow: `NicknameSetup` → `RoomManager` (create/join) → `LobbyRoom` (character pick + ready) → `GameScene`
+- Agent8 gameserver integration (`@agent8/gameserver`): `joinRoom`, `leaveRoom`, `setCharacter`, `toggleReady`, `updateMyState`, `revive`, `applyDamage`, `handlePing`
+- Local player on `RigidBodyPlayer` with full humanoid animation set (idle, idle_01, walk, run, fast_run, jump, punch, punch_01, kick, kick_01, kick_02, melee attack, cast, hit, die) and dirty-checked, throttled state sync (~10 Hz)
+- Server-authoritative death / revive: local player subscribes to its own server state, triggers `DIE`, and auto-calls `revive`
+- Remote players via `NetworkContainer` + `RemotePlayer` (`NetworkObject` + `CapsuleCollider` + `CharacterRenderer`) with imperative `syncState` and floating nickname billboard
+- Quarter-view camera following the local character (`QuarterViewController`, gated on physics ready)
+- Physics-ready bootstrap (`MapPhysicsReadyChecker`) and keyboard input (`KeyboardControls` with WASD/Arrows, Space, Shift, Q/E/R/F)
+- Network telemetry: RTT sampler + trimmed average in `networkSyncStore`, rendered by the `RTT` UI component in the game header
+- Character selection UI with live 3D preview (`CharacterPreview` + `OrbitControls`) inside `LobbyRoom`
+- Scene lighting: ambient + `FollowLight` + sunset environment preset; flat `Floor`
+
+## Installed but not wired
+
+- `@react-three/postprocessing` — no effect pipeline
+- `lucide-react` — no icons used
+- `sendMessage` / chat broadcast in `server.js` — no chat UI
+- `sendEffectEvent` / `sendFireballEffect` in `server.js` — no effect system on the client
+- `applyDamage` server method — no combat hit-detection code calls it
+- `stats.maxHp` / `stats.currentHp` — tracked server-side, no HUD
+- World geometry — only a flat `Floor`
+</content>
+</invoke>

--- a/basic-3d-quarterview-multiplay/PROJECT/Structure.md
+++ b/basic-3d-quarterview-multiplay/PROJECT/Structure.md
@@ -1,106 +1,57 @@
-# Basic 3D Free View
+# Structure — basic-3d-quarterview-multiplay
 
-## Project Summary
+## `src/main.tsx`, `src/App.tsx`
 
-This project is a 3D character controller with free view camera, built using Three.js and React Three Fiber. It features a player character that can be controlled with keyboard inputs in a 3D environment. The character supports various animations including idle, walking, running, jumping, punching, and hit reactions. The camera follows the character with a free-view perspective, allowing users to navigate through the 3D space. This project is intended for multi-player gameplay.
+Entry point and root component. `App` owns the top-level flow state (`connected`, `nickname`, `currentRoomId`, `roomStarted`, `isReady`) and switches between `NicknameSetup`, `RoomManager`, `LobbyRoom`, and `GameScene`. It subscribes to `subscribeRoomState` / `subscribeRoomMyState` and wires the `GameServer` instance into `networkSyncStore`.
 
-## Implementation Strategy
+## `src/App.css`, `src/index.css`
 
-This project uses a **Three.js-based 3D approach** because:
+Component styles and global base (Tailwind directives, fonts).
 
-- It requires real-time 3D character animation and control
-- Three.js provides efficient 3D rendering in web browsers
-- React Three Fiber simplifies integration with React components
-- The vibe-starter-3d library provides essential character rendering and animation tools
+## `src/assets.json`
 
-Key technologies:
+Asset manifest — character model URLs (multiple selectable characters) and animation URLs.
 
-- Three.js for 3D rendering
-- React Three Fiber for React integration
-- @react-three/rapier for physics simulation
-- @react-three/drei for useful Three.js helpers
-- vibe-starter-3d for character rendering and animation
-- Tailwind CSS for styling
+## `src/server.js`
 
-## Implemented Features
+Agent8 gameserver methods: `joinRoom`, `leaveRoom`, `setCharacter`, `toggleReady`, `updateMyState`, `handlePing` (RTT), `applyDamage`, `sendMessage`, `sendEffectEvent`, plus `$roomTick`.
 
-- Keyboard-controlled character movement (WASD/Arrow keys)
-- Character animations (idle, walk, run, jump, punch, hit, die)
-- Free view camera that follows the character
-- Physics-based character movement with collision detection
-- Character state management system
-- 3D environment with floor
-- Directional and ambient lighting
-- Animation system with support for looping and one-shot animations
-- Character bounding box calculations
-- Pointer lock for immersive control
+## `src/constants/`
 
-## File Structure Overview
+- **`character.ts`** — animation state ids (idle, idle_01, walk, run, fast_run, jump, punch, kick, melee attack, cast, hit, die) and `DEFAULT_HEIGHT`.
+- **`controls.ts`** — `KeyboardControls` map: WASD/Arrow keys, Space (jump), Shift (sprint), Q/E/R/F (actions).
+- **`rigidBodyObjectType.ts`** — rigid-body category enum (local player, enemy, monster, wall, obstacle, item, bullet, floor, plotting board).
 
-### `src/main.tsx`
+## `src/types/`
 
-- Entry point for the application.
-- Sets up React rendering and mounts the `App` component.
+- **`user.ts`** — `UserState` (account, nickname, isReady, character, position, rotation, state, stats{maxHp, currentHp}).
+- **`index.ts`** — re-exports.
 
-### `src/App.tsx`
+## `src/stores/` (Zustand)
 
-- Main application component.
-- Sets up the Colyseus client and manages the room state (`RoomManager`) and the game scene (`GameScene`).
-- Handles routing or state-based rendering between nickname setup, lobby screen, and game screen.
+- **`gameStore.ts`** — global lifecycle; holds `isMapPhysicsReady`.
+- **`playerStore.ts`** — registry of local + remote rigid-body refs keyed by account (`registerPlayerRef`, `unregisterPlayerRef`, `getPlayerRef`).
+- **`networkSyncStore.ts`** — `GameServer` handle plus RTT sampler. `setServer(server)` starts a 3 s `handlePing` loop, keeps last 5 RTTs, and publishes the trimmed average as `rtt`.
 
-### `src/App.css`
+## `src/components/r3f/` (inside `Canvas`)
 
-- Defines the main styles for the `App` component and its child UI elements.
+- **`Player.tsx`** — local player. Wraps `RigidBodyPlayer` + `CharacterRenderer`, reads keyboard/mouse via `useKeyboardControls` + `useMouseControls`, runs `determinePlayerState` against the full `CharacterState` set, and pushes state to the server through a throttled + dirty-checked `updateMyState` call. Subscribes to `subscribeRoomMyState` to react to server-side death and auto-calls `revive`.
+- **`RemotePlayer.tsx`** — `forwardRef` component for other users. Wraps `NetworkObject` + `CapsuleCollider` + `CharacterRenderer`; exposes `syncState(state, position, rotation)` via `useImperativeHandle` for interpolation. Renders a floating nickname via `@react-three/drei` `Billboard` + `Text`.
+- **`NetworkContainer.tsx`** — subscribes to `subscribeRoomState` + `subscribeRoomAllUserStates`, maintains the set of ready remote players (excluding self), creates a `RemotePlayerHandle` ref per account, and drives `ref.syncState(...)` on every update.
+- **`Experience.tsx`** — 3D scene contents mounted inside `GameScene`'s `Canvas`: `ambientLight`, `FollowLight`, sunset `Environment`, local `Player`, and `Floor`.
+- **`MapPhysicsReadyChecker.tsx`** — raycasts downward each frame to detect map geometry; flips `isMapPhysicsReady` on hit or after a 180-frame timeout. Ignores capsules and sensor colliders.
+- **`Floor.tsx`** — flat ground plane with a fixed physics collider.
+- **`CharacterPreview.tsx`** — static IDLE-only `CharacterRenderer` used by the lobby preview `Canvas`.
 
-### `src/index.css`
+## `src/components/scene/`
 
-- Defines global base styles, Tailwind CSS directives, fonts, etc., applied throughout the application.
+- **`GameScene.tsx`** — in-game screen. Renders a header (Leave Game, `RTT`, Room ID) plus a `Canvas` with `KeyboardControls`, Rapier `Physics`, `MapPhysicsReadyChecker`, an extra `FollowLight`, `QuarterViewController` (gated on `isMapPhysicsReady`), `Experience`, and `NetworkContainer`. Resets `isMapPhysicsReady` on unmount.
+- **`RoomManager.tsx`** — pre-room screen: "Create New Room" and "Join Existing Room" (by ID) with a back-to-nickname button.
+- **`LobbyRoom.tsx`** — in-room waiting screen. Uses `useRoomAllUserStates`, lets the user pick from `Assets.characters`, calls `setCharacter` / `toggleReady`, shows participant list with ready badges, and renders a corner character preview `Canvas` (`CharacterPreview` + `OrbitControls`).
+- **`NicknameSetup.tsx`** — initial nickname entry form.
 
-### `src/assets.json`
+## `src/components/ui/` (DOM overlay)
 
-- File for managing asset metadata. Includes character model and animation information.
-
-### `src/constants/`
-
-- Directory defining constant values used throughout the application.
-  - **`controls.ts`**: Defines settings that map keyboard inputs (WASD, arrow keys, etc.) to corresponding actions (movement, jump, etc.).
-  - **`character.ts`**: Defines character-related constants (animation states, speed, etc.).
-
-### `src/types/`
-
-- Directory defining TypeScript types used in the application (e.g., `PlayerState`, `PlayerInput`).
-
-### `src/hooks/`
-
-- Directory defining reusable React hooks (e.g., `useKeyboardControls`).
-
-### `src/stores/`
-
-- Directory containing state management logic (e.g., Zustand).
-  - **`playerStore.ts`**: Manages player-related state (nickname, selected character, etc.).
-  - **`roomStore.ts`**: Manages Colyseus Room related state (room info, player list, etc.).
-
-### `src/components/`
-
-- Directory managing React components categorized by function.
-
-  - **`r3f/`**: Contains 3D components related to React Three Fiber.
-
-    - **`Experience.tsx`**: Main component responsible for setting up the 3D environment. Includes lighting `ambientLight`, environmental elements `Environment`, the local player `Player` wrapped in `QuarterViewController`, the floor `Floor`, and the `FollowLight` component that follows the player.
-    - **`Floor.tsx`**: Component defining and visually representing the ground plane in the 3D space. Has physical properties.
-    - **`Player.tsx`**: Component handling the logic related to the local player character model (movement, rotation, animation state management, input processing, and sending to the server).
-    - **`RemotePlayer.tsx`**: Component rendering remote player character models, animations, positions, etc., based on the state received from the server.
-    - **`NetworkContainer.tsx`**: Manages all remote player states received from the server and renders a `RemotePlayer` component for each remote player.
-    - **`CharacterPreview.tsx`**: Component for previewing character models, e.g., on the character selection screen.
-    - **`EffectContainer.tsx`**: Component managing and applying postprocessing effects (e.g., Bloom, SSR).
-    - **`effects/`**: Directory containing individual visual effect components (specific effect files can be added).
-
-  - **`scene/`**: Contains components related to 3D scene setup and game state.
-
-    - **`GameScene.tsx`**: Sets up the React Three Fiber `Canvas` component (implementing the Pointer Lock feature), utilizes `KeyboardControls` for handling keyboard inputs, configures the physics simulation using the `Physics` component from `@react-three/rapier`, includes the network container `NetworkContainer` and loads the `Experience` component with `Suspense` to initialize the 3D rendering environment.
-    - **`NicknameSetup.tsx`**: UI component where the user enters their nickname and selects a character.
-    - **`LobbyRoom.tsx`**: Component that joins the Colyseus lobby room, displays the list of available game rooms, and provides UI for creating/joining rooms.
-    - **`RoomManager.tsx`**: Component responsible for Colyseus Room connection and state management. Conditionally renders `NicknameSetup`, `LobbyRoom`, `GameScene`, etc., based on the connection status with the server.
-
-  - **`ui/`**: Contains general UI components.
-    - **`RTT.tsx`**: UI component for displaying Round Trip Time (network latency).
+- **`RTT.tsx`** — reads `networkSyncStore.rtt` and renders current ping in the `GameScene` header.
+</content>
+</invoke>

--- a/basic-3d-quarterview/PROJECT/Context.md
+++ b/basic-3d-quarterview/PROJECT/Context.md
@@ -1,0 +1,25 @@
+# Context — basic-3d-quarterview
+
+## Project Overview
+
+Three.js + React Three Fiber scaffold with a physics-based character controller and a fixed quarter-view camera (angled top-down) that follows the player. Player runs on `RigidBodyPlayer` with a humanoid animation set and a combat-action layer (punch, kick, melee, cast); camera follows via `QuarterViewController`; map physics are gated by a raycast-based ready check. Asset preloading runs before the scene mounts. Zustand stores are pre-split for multiplayer, and `@agent8/gameserver` is installed but no networking is wired.
+
+## Tech Stack
+
+_Exact versions are in `package.json`._
+
+- **Rendering**: Three.js, `@react-three/fiber`, `@react-three/drei`
+- **Physics**: `@react-three/rapier`
+- **Character framework**: `vibe-starter-3d` (`QuarterViewController`, `RigidBodyPlayer`, `CharacterRenderer`, `FollowLight`)
+- **Multiplayer (unwired)**: `@agent8/gameserver`
+- **State**: Zustand
+- **Build / Lang**: Vite, TypeScript
+- **Styling**: Tailwind CSS
+
+## Critical Memory
+
+- Player must be built on `RigidBodyPlayer` and camera on `QuarterViewController` with `followCharacter={true}`; the physics bootstrap depends on this pipeline.
+- Physics stay paused until `gameStore.isMapPhysicsReady` is `true`. `MapPhysicsReadyChecker` releases it via a downward raycast — new map geometry must be reachable by it.
+- `App.tsx` gates the scene behind `PreloadScene`; every asset referenced from gameplay must be listed in `src/assets.json` so it is fetched before `GameScene` mounts.
+- Handle player collisions via `RigidBodyPlayer.onTriggerEnter` / `onTriggerExit`, switching on `RigidBodyObjectType` tags.
+- Combat actions (punch, kick, meleeAttack, cast) flow through `playerActionStore`; the `Player` component locks controls during action animations and releases them on `onAnimationComplete`.

--- a/basic-3d-quarterview/PROJECT/Requirements.md
+++ b/basic-3d-quarterview/PROJECT/Requirements.md
@@ -1,0 +1,18 @@
+# Requirements — basic-3d-quarterview
+
+## Coding Patterns
+
+- Stores are concern-split (Zustand): `gameStore`, `localPlayerStore`, `multiPlayerStore`, `playerActionStore` — do not cross-write. `playerActionStore` is a plain object; mutate it only through `setPlayerAction` / `resetAllPlayerActions`.
+- R3F goes under `components/r3f/`, DOM under `components/ui/`; `GameScene.tsx` stitches them and must not render 3D directly.
+- Scene graph lives in `Experience.tsx`; controller, lighting, and physics wiring live in `GameSceneCanvas.tsx` — keep them separate.
+- Extend `Player.tsx` by adding animation states and action branches (update `animationConfigMap`, `handleAnimationComplete`, and `updatePlayerState`), not by forking.
+- New gameplay actions go through `playerActionStore` and `InputController` key/action maps, not ad-hoc listeners.
+- No magic values — animation ids in `constants/character.ts`, rigid-body types in `constants/rigidBodyObjectType.ts`.
+- Every new runtime asset must be registered in `src/assets.json` so `PreloadScene` covers it.
+
+## Known Issues / Constraints
+
+- `QuarterViewController` owns camera angle and follow behavior; there is no in-repo camera override.
+- `MapPhysicsReadyChecker` has a 180-frame raycast timeout — very slow map loads may expire it.
+- Camera does not orbit, so the nipplejs joystick occupies the left half of the screen on mobile; there is no right-side look stick.
+- `usePlayerActionStore` is module-level shared state; it does not trigger React re-renders on change.

--- a/basic-3d-quarterview/PROJECT/Status.md
+++ b/basic-3d-quarterview/PROJECT/Status.md
@@ -1,0 +1,22 @@
+# Status — basic-3d-quarterview
+
+## Implemented
+
+- Quarter-view camera following the character (`QuarterViewController` with `followCharacter`)
+- Physics-based character controller (`RigidBodyPlayer`) with humanoid animation set (idle, idle_01, walk, run, fast_run, jump, punch, punch_01, kick, kick_01, kick_02, melee_attack, cast, hit, die)
+- Combat action layer (`playerActionStore`) with control-lock + `onAnimationComplete` recovery for punch / kick / melee / cast
+- Physics-ready bootstrap (`MapPhysicsReadyChecker` + `LoadingScreen`)
+- Pre-game asset preloading (`PreloadScene`) covering GLTF, textures, audio, video, and generic URLs from `assets.json`
+- Desktop input (keyboard + mouse action buttons) and mobile input (`nipplejs` joystick + on-screen Attack / Jump buttons)
+- Collision triggers via `RigidBodyPlayer.onTriggerEnter` / `onTriggerExit`
+- Scene lighting: ambient + `FollowLight` + sunset environment preset
+- Position streaming into `localPlayerStore` and rigid-body registration into `multiPlayerStore`
+
+## Installed but not wired
+
+- `@agent8/gameserver` — account hook used for registration only; no networking / session code
+- `@react-three/postprocessing` — no effect pipeline
+- `lucide-react` — no icon usage in UI yet
+- World geometry — only a flat `Floor`
+- Death / revive flow — `isDying` / `isRevive` branches in `Player.tsx` are stubbed with `false`
+- `onTriggerEnter` / `onTriggerExit` handlers are empty TODOs

--- a/basic-3d-quarterview/PROJECT/Structure.md
+++ b/basic-3d-quarterview/PROJECT/Structure.md
@@ -1,123 +1,46 @@
-# 3D Quarter View Game
+# Structure — basic-3d-quarterview
 
-## Project Summary
+## `src/main.tsx`, `src/App.tsx`
 
-This project is a 3D game where players control a character from a quarter view perspective. The game features character animations, physics-based movement, and a 3D environment. Players can control the character using keyboard to perform various actions (idle, running, jumping, attacking, etc.). This project is intended for single-player gameplay with an emphasis on character control and animation.
+Entry point and root component. `App` holds an `isLoading` flag that renders `PreloadScene` until assets finish loading, then swaps in `GameScene`.
 
-## Implementation Strategy
+## `src/App.css`, `src/index.css`
 
-This game uses a **Three.js-based 3D approach**:
+Component styles and global base (Tailwind directives, fonts).
 
-- React Three Fiber for 3D rendering in a React environment
-- @react-three/rapier for physics simulation
-- vibe-starter-3d library for character rendering and animation
-- Quarter view camera setup providing an angled top-down view of the game world
+## `src/assets.json`
 
-Key technologies:
+Asset manifest — character model and animation URLs. Consumed by both `PreloadScene` (for preloading) and `Player.tsx` (for `CharacterRenderer` + `animationConfigMap`).
 
-- Three.js - 3D rendering
-- React Three Fiber - React integration
-- @react-three/rapier - Physics simulation
-- @react-three/drei - Useful Three.js helpers
-- vibe-starter-3d (v0.4.0) - Advanced character rendering, animation, and physics integration
-- Tailwind CSS - UI composition
-- Zustand - State management
+## `src/constants/`
 
-## Core Features
+- **`character.ts`** — animation state ids (idle, idle_01, walk, run, fast_run, jump, punch, punch_01, kick, kick_01, kick_02, melee_attack, cast, hit, die).
+- **`rigidBodyObjectType.ts`** — rigid-body category enum (local_player, enemy, monster, wall, obstacle, item, bullet, floor, plotting_board).
 
-- **Advanced Character System**: Comprehensive character rendering with physics-based rigid body integration
-- **Animation Management**: Complete animation system supporting idle, run, sprint, jump, punch, kick, normal_attack, cast, and other character states
-- **Physics Integration**: Full physics simulation with collision detection and rigid body object type definitions
-- **Quarter View Camera**: Fixed quarter-view perspective with character following for optimal gameplay experience
-- **Interactive Controls**: Keyboard-based navigation (WASD for movement, QERF for actions) with mouse interaction support
-- **Visual Environment**: Interactive ground plane with environmental collision detection and debugging grid overlay
-- **State Management**: Robust character state transitions and player reference tracking for multiplayer readiness
-- **Asset Management**: Comprehensive preloading system with progress indication for smooth gameplay
-- **3D Rendering**: High-quality 3D model rendering with smooth animation transitions
-- **Environmental Lighting**: Dynamic lighting system with follow light for enhanced visual experience
+> Keyboard and joystick bindings live inside `components/ui/InputController.tsx`; no `controls.ts` ships.
 
-## File Structure Overview
+## `src/stores/` (Zustand)
 
-#### `src/main.tsx`
+- **`gameStore.ts`** — global lifecycle; holds `isMapPhysicsReady`.
+- **`localPlayerStore.ts`** — local-player state (position, speed).
+- **`multiPlayerStore.ts`** — registry of remote-player rigid-body refs.
+- **`playerActionStore.ts`** — combat action flags (punch, kick, meleeAttack, cast). Plain object exposed via `usePlayerActionStore()` (not a Zustand store despite the filename).
 
-- Entry point for the application.
-- Sets up React rendering and mounts the `App` component.
+## `src/components/r3f/` (inside `Canvas`)
 
-#### `src/App.tsx`
+- **`GameSceneCanvas.tsx`** — R3F `Canvas` root. Hosts Rapier `Physics` (paused until `isMapPhysicsReady`), `QuarterViewController` with `followCharacter`, `FollowLight`, and mounts `MapPhysicsReadyChecker` (only while not ready) plus `Experience`.
+- **`Experience.tsx`** — scene contents: ambient light, sunset `Environment`, `Player`, `Floor`.
+- **`MapPhysicsReadyChecker.tsx`** — raycasts downward each frame to detect map geometry; flips `isMapPhysicsReady` on hit or after a 180-frame timeout. Ignores capsules and sensor colliders.
+- **`Player.tsx`** — wraps `RigidBodyPlayer` + `CharacterRenderer`. Drives animation state from `useControllerStore` movement + `playerActionStore` combat flags, locks controls during action animations, and resolves back to idle via `onAnimationComplete`. Registers its rigid body into `multiPlayerStore` and streams position (threshold-gated) into `localPlayerStore`.
+- **`Floor.tsx`** — flat 100x100 ground plane with a fixed cuboid collider.
 
-- Main application component.
-- Configures the overall layout and includes the `GameScene` component.
-- Manages loading state and switches between `PreloadScene` and `GameScene`.
+## `src/components/scene/`
 
-### `src/App.css`
+- **`GameScene.tsx`** — layout shell stitching `GameSceneCanvas` (3D) and `GameSceneUI` (DOM overlay). Contains performance-critical warnings against mixing concerns.
+- **`PreloadScene.tsx`** — walks every category in `assets.json`, loads each URL with the right loader (GLTF / texture / audio / video / fetch) via a shared `THREE.LoadingManager`, renders a progress bar, and calls `onComplete` when done.
 
-- Defines the main styles for the `App` component and its child UI elements.
+## `src/components/ui/` (DOM overlay)
 
-### `src/index.css`
-
-- Defines global base styles, Tailwind CSS directives, fonts, etc., applied throughout the application.
-
-#### `src/assets.json`
-
-- File for managing asset metadata. Includes character model and animation information.
-
-### `src/constants/`
-
-- Directory defining constant values used throughout the application.
-  - **`controls.ts`**: Defines settings that map keyboard inputs (WASD, arrow keys, etc.) to corresponding actions (movement, jump, etc.).
-  - **`character.ts`**: Defines character-related constants (animation states, speed, etc.).
-  - **`rigidBodyObjectType.ts`**: Defines physics object types for collision detection and interaction systems.
-
-### `src/stores/`
-
-- Directory containing state management stores using Zustand.
-  - **`gameStore.ts`**: Store that manages the overall game state. Tracks and controls the readiness state of the map physics system (`isMapPhysicsReady`). This state is used to determine physics simulation pause/resume and loading screen display.
-  - **`localPlayerStore.ts`**: Store that manages the local player's state, such as position tracking.
-  - **`multiPlayerStore.ts`**: Store that manages multiple connected players' rigid body references for multiplayer functionality, including registration, unregistration, and retrieval of player references.
-  - **`playerActionStore.ts`**: Store that manages player action states including combat actions (punch, kick, meleeAttack, cast) with support for setting, getting, and resetting action states.
-
-### `src/components/`
-
-- Directory managing React components categorized by function.
-
-  - **`r3f/`**: Contains 3D components related to React Three Fiber.
-
-    - **`Experience.tsx`**: Main component responsible for the primary 3D scene configuration. Includes lighting `ambientLight`, environmental elements `Environment`, the `Player` component, and the floor `Floor`. It renders the core visual and interactive elements within the physics simulation configured in `GameScene.tsx`.
-    - **`Floor.tsx`**: Component defining and visually representing the ground plane in the 3D space. Has physical properties.
-    - **`GameSceneCanvas.tsx`**: React Three Fiber Canvas component that renders the 3D game world with physics simulation and controller setup.
-    - **`MapPhysicsReadyChecker.tsx`**: Component that checks if the map physics system is ready by performing raycasting from above downward to detect map geometry and ensures physics interactions are properly initialized before gameplay begins. Performs checks every frame until valid map geometry is detected, with a timeout after 180 frames to prevent infinite checking. Excludes Capsule shapes (likely characters/objects) and sensor colliders from the inspection.
-    - **`Player.tsx`**: Advanced player component integrating RigidBodyPlayer with CharacterRenderer for comprehensive character management, physics interactions, and animation state management with collision detection capabilities.
-
-  - **`scene/`**: Contains components related to scene setup.
-
-    - **`GameScene.tsx`**: Main game scene component that serves as a layout container arranging the game UI and 3D Canvas. Contains critical performance warnings and guidelines to prevent re-rendering issues. Includes the `GameSceneCanvas` and `GameSceneUI` components in a proper layered structure where the Canvas renders the 3D world and UI components render as overlays.
-    - **`PreloadScene.tsx`**: Manages asset preloading before the game starts. Loads all assets defined in assets.json (models, textures, etc.) and displays a loading progress bar. Ensures all assets are loaded before the game begins.
-
-  - **`ui/`**: Contains UI components for the game interface.
-    - **`GameSceneUI.tsx`**: Component that manages UI overlays for the game scene.
-    - **`LoadingScreen.tsx`**: Loading screen component displayed during game loading.
-    - **`InputController.tsx`**: Manages all input handling including keyboard, mouse, and touch controls with virtual joystick support for mobile devices and action buttons for combat actions (punch, kick, cast) and movement controls.
-
-### Key Libraries & Components from External Sources
-
-- **`vibe-starter-3d`**: A library providing foundational 3D game components and utilities.
-  - **`QuarterViewController`**: Wraps the player character and manages quarter view navigation by implementing a character controller with physics. It handles character movement, rotation, and camera following with a fixed quarter-view perspective.
-  - **`CharacterRenderer`**: Renders 3D character models with animations from glTF/GLB files. Manages animation states and transitions based on player actions.
-  - **`useControllerState`**: A React hook that provides control state management for the character, including:
-    - `setEnableInput`: Function to enable/disable player input controls
-    - `rigidBody`: Reference to the physics body for the character
-  - **`useMouseControls`**: A React hook that provides access to mouse input state (left/right buttons and positions).
-
-### Quarter View System Implementation
-
-The quarter view control system is implemented through a combination of components:
-
-1. **Controller System**: `QuarterViewController` from the vibe-starter-3d library handles the physics-based movement of the character based on keyboard inputs, maintaining a fixed camera angle that provides the quarter view perspective with character following.
-
-2. **Input Management**: Keyboard inputs are captured through React Three Fiber's `useKeyboardControls` hook, which maps WASD/arrow keys to movement, and additional keys (Q/E/R/F) to character actions, with mouse controls for additional interactions.
-
-3. **State Management**: `useControllerState` hook provides shared state between components, allowing different parts of the application to access and modify the character's state. Additionally, `playerStore` manages physics body references for multiplayer support.
-
-4. **Animation Management**: `Player` component with `RigidBodyPlayer` integration determines appropriate animations based on movement and action states, transitioning between idle, walking, running, and action animations as needed, with full collision detection capabilities.
-
-5. **Asset Management**: `PreloadScene` component ensures all 3D models, textures, and other assets are preloaded before gameplay begins, providing a smooth user experience with a visual loading indicator.
+- **`GameSceneUI.tsx`** — UI overlay container; mounts `InputController` and shows `LoadingScreen` while `isMapPhysicsReady` is `false`.
+- **`LoadingScreen.tsx`** — fullscreen spinner; auto-wraps in `<Html>` if rendered inside the Canvas.
+- **`InputController.tsx`** — keyboard + mouse + touch input. Keyboard map (WASD/Arrows, Space, Shift) and action map (F/Mouse0 punch, G/Mouse2 kick, Q/C melee, E/Mouse1 cast) are declared inline. On mobile (`IS_MOBILE`) it injects a `nipplejs` virtual joystick on the left half of the screen plus on-screen Attack / Jump buttons; feeds `useInputStore` (vibe-starter-3d) and `playerActionStore`.

--- a/basic-3d-sideview-multiplay/PROJECT/Context.md
+++ b/basic-3d-sideview-multiplay/PROJECT/Context.md
@@ -1,0 +1,28 @@
+# Context — basic-3d-sideview-multiplay
+
+## Project Overview
+
+3D side-view platformer with multiplayer wired through `@agent8/gameserver`. Flow goes Nickname → RoomManager → LobbyRoom (character select + ready) → GameScene. Local player runs on `SideViewController` + `CharacterRenderer`; remote players render via `NetworkObject` inside `NetworkContainer`, which subscribes to per-user room state. Player transform/state is throttled to the server (100ms / 0.01m / 0.01rad dirty check); fireball/explosion effects are broadcast through a room message channel. Floor is a seed-based random platform chain driven by `roomId`.
+
+## Tech Stack
+
+_Exact versions are in `package.json`._
+
+- **Rendering**: Three.js, `@react-three/fiber`, `@react-three/drei`
+- **Physics**: `@react-three/rapier`
+- **Character framework**: `vibe-starter-3d` (`SideViewController`, `CharacterRenderer`, `NetworkObject`, `CharacterUtils`)
+- **Multiplayer**: `@agent8/gameserver` (`server.js` remote functions + room state subscriptions)
+- **State**: Zustand (`effectStore`, `networkSyncStore`)
+- **Utils**: `lodash/throttle`
+- **Build / Lang**: Vite, TypeScript
+- **Styling**: Tailwind CSS
+
+## Critical Memory
+
+- App flow is gated by `connected` → `nickname` → `currentRoomId` → `roomState.gameStarted && roomMyState.isReady`. `GameScene` only mounts after the ready flag flips; `LobbyRoom` handles character pick + ready toggle.
+- Local player transform sync goes through `Player.tsx` → `server.remoteFunction('updatePlayerTransform', ...)`, throttled at 100ms with dirty-check thresholds (`POSITION_CHANGE_THRESHOLD` 0.01, `ROTATION_CHANGE_THRESHOLD` 0.01). Do not bypass the throttle.
+- Remote players are owned by `NetworkContainer`: it keeps a `RemotePlayerHandle` ref per account and calls `syncState(state, position, rotation)` on each `subscribeRoomAllUserStates` tick. Only users with `isReady && transform` are rendered.
+- Effects flow both ways: locally add via `useEffectStore.addEffect`, then `server.remoteFunction('sendEffectEvent', ...)`; incoming `onRoomMessage('effect-event', ...)` calls `addEffect` after filtering self-sender.
+- `networkSyncStore.setServer(server)` must be called from `App.tsx` after `useGameServer` connects — it drives the ping/pong RTT loop used by `RTT.tsx`.
+- Character model URLs come from `src/assets.json`; `characterKey` is the map key (e.g. `knight`). `LobbyRoom` writes the key via `setCharacter`, `App.tsx` reads it back through `subscribeRoomMyState` and hands it to `GameScene` → `Experience` → `Player`.
+- `Floor` is deterministic per room: it seeds its RNG from `roomId`, so every client in the same room renders the same platform layout.

--- a/basic-3d-sideview-multiplay/PROJECT/Requirements.md
+++ b/basic-3d-sideview-multiplay/PROJECT/Requirements.md
@@ -1,0 +1,22 @@
+# Requirements — basic-3d-sideview-multiplay
+
+## Coding Patterns
+
+- Keep the flow states in `App.tsx` (`nickname` / `currentRoomId` / `roomStarted` / `isReady`); screen components stay presentational and take callbacks.
+- Never write user/room state directly from the client — go through `server.remoteFunction` (`joinRoom`, `leaveRoom`, `setCharacter`, `toggleReady`, `updatePlayerTransform`, `sendEffectEvent`, `applyDamage`).
+- Local player transform sync lives in `Player.tsx` only; reuse its throttle + dirty-check thresholds (`NETWORK_CONSTANTS.SYNC`) rather than spawning new sync paths.
+- Remote players are driven via `RemotePlayerHandle.syncState` from `NetworkContainer`; do not mount `RemotePlayer` directly elsewhere.
+- Effects are spawned through `useEffectStore.addEffect` then broadcast via `sendEffectEvent`; incoming `effect-event` messages call `addEffect` again — filter self-sender to avoid duplicates.
+- Stores are concern-split: `networkSyncStore` (server handle + RTT), `effectStore` (active effects). Do not cross-write.
+- R3F components under `components/r3f/`, DOM flow screens under `components/scene/`, DOM overlays under `components/ui/`. `GameScene.tsx` is the only place that mounts the `Canvas`.
+- No magic values: animation ids in `constants/character.ts`, keyboard bindings in `constants/controls.ts`, effect types in `types/effect.ts`, asset URLs in `assets.json`.
+- Self-hit filtering in `EffectContainer` depends on `rigidBody.userData.account`; preserve the `userData` write in `Experience.tsx` and `RemotePlayer.tsx`.
+
+## Known Issues / Constraints
+
+- `useNetworkSync.ts` hook ships but is not wired — RTT is driven by `networkSyncStore`. Pick one before adding new ping logic.
+- `server.js` `sendEffectEvent` validates a legacy shape (`startPosition` / `direction` / `targetPosition`) that does not match the current client payload (`type` + `config`); effect broadcasts still work because validation failures are caught, but the validator needs updating if stricter checks are desired.
+- `@react-three/postprocessing` is installed but no effect pipeline is mounted.
+- `Floor` always generates 15 blocks starting at `x = -40`; platform count/range is not configurable.
+- Pointer lock / mobile input layer is absent — controls assume desktop keyboard only.
+- `LobbyRoom` selects character by `Assets.characters` key; renaming asset keys breaks saved `character` values in existing rooms.

--- a/basic-3d-sideview-multiplay/PROJECT/Status.md
+++ b/basic-3d-sideview-multiplay/PROJECT/Status.md
@@ -1,0 +1,19 @@
+# Status — basic-3d-sideview-multiplay
+
+## Implemented
+
+- End-to-end flow: nickname entry → room create/join → lobby (character select + ready) → in-game scene
+- `@agent8/gameserver` integration (`server.js` remote functions) with room / per-user / room-message subscriptions
+- Local character on `SideViewController` with orthographic camera; animation state machine (idle, walk, run, jump, punch, hit, die)
+- Throttled transform/state sync to server (100ms, 0.01m / 0.01rad dirty check)
+- Remote player rendering via `NetworkContainer` + `RemotePlayer` (`NetworkObject` + capsule collider + nickname billboard)
+- Effect system: local fireball cast (E key) → server broadcast → remote mirroring; fireball collision spawns local explosion with self-hit filtering
+- RTT ping/pong via `networkSyncStore` (3s interval, trimmed average) rendered by `RTT` overlay
+- Seed-based random platform floor driven by `roomId` so all clients in a room see the same layout
+- Lobby character preview via in-panel `CharacterPreview` `Canvas`
+
+## Installed but not wired
+
+- `@react-three/postprocessing` — no effect pipeline
+- `useNetworkSync` hook — superseded by `networkSyncStore`
+- `server.js` `sendFireballEffect` (legacy) / `applyDamage` / `sendMessage` — not called by the current client

--- a/basic-3d-sideview-multiplay/PROJECT/Structure.md
+++ b/basic-3d-sideview-multiplay/PROJECT/Structure.md
@@ -1,155 +1,60 @@
-# 3D Side-View Platform Game with Multiplayer
+# Structure — basic-3d-sideview-multiplay
 
-## Project Overview
+## `src/main.tsx`, `src/App.tsx`
 
-This project extends the basic 3D side-view platform game by adding robust multiplayer functionality. Players can now create or join rooms, select characters, and play together in the same 3D environment. The game features real-time synchronization of player positions, states, and actions, allowing for collaborative gameplay. It maintains the core Mario-style platforming mechanics while adding social interaction elements.
+Entry point and root. `App` drives the full client flow: it reads `useGameServer()`, wires `networkSyncStore.setServer`, subscribes to `subscribeRoomState` (for `gameStarted`) and `subscribeRoomMyState` (for `character` + `isReady`), and switches between `NicknameSetup` → `RoomManager` → `LobbyRoom` → `GameScene`. `joinRoom` / `leaveRoom` are invoked as `server.remoteFunction` calls.
 
-## Implementation Strategy
+## `src/App.css`, `src/index.css`
 
-This game uses a **3D Three.js-based approach with Network Synchronization**:
+Component styles and global Tailwind base.
 
-- 3D character models with physics-based environment
-- Efficient 3D rendering through Three.js
-- React component integration via React Three Fiber
-- Character and camera controls through vibe-starter-3d library
-- Real-time multiplayer using @agent8/gameserver
-- Network state synchronization with optimized data transfer
+## `src/assets.json`
 
-Key technologies:
+Asset manifest — character `.glb` URLs (keyed by character name) and animation URLs used by `CharacterRenderer`.
 
-- Three.js: 3D rendering
-- React Three Fiber: React integration
-- @react-three/rapier: Physics simulation
-- vibe-starter-3d: Character control and rendering
-- @agent8/gameserver: Multiplayer functionality
-- Zustand: State management
-- Tailwind CSS: UI composition
+## `src/constants/`
 
-## Implemented Features
+- **`character.ts`** — `CharacterState` map (idle, walk, run, jump, punch, hit, die) and `DEFAULT_HEIGHT`.
+- **`controls.ts`** — `keyboardMap` for `@react-three/drei` `KeyboardControls` (up/down/left/right, jump, run, action1–4, magic).
 
-- 3D character model rendering
-- Character animations (idle, walk, run, jump, attack)
-- Side-view camera controls
-- Keyboard-based character control
-- Physics-based collision detection
-- Seed-based random platform generation
-- Character state system (idle, walk, run, jump, punch, hit, die)
-- User authentication with nickname
-- Room creation and management
-- Character selection system
-- Real-time player synchronization
-- Network latency measurement (RTT)
-- Health and damage system
-- Chat messaging between players
-- Special effect sharing (fireballs)
+## `src/types/`
 
-## File Structure Overview
+- **`user.ts`** — `UserState` (account, nickname, isReady, character, transform, state, stats).
+- **`player.ts`** — `PlayerInputs` (movement/action flags) and `PlayerRef` (bounding box handle).
+- **`effect.ts`** — `EffectType` enum (FIREBALL, EXPLOSION), `EffectData`, `ActiveEffect`, `EffectEventMessage`.
+- **`index.ts`** — barrel export.
 
-### server.js
+## `src/store/` (Zustand)
 
-- Game server implementation
-- Handles room management, player synchronization, and game logic
-- Implements remote functions for client-server communication
-- Manages player states, transform data, and effects
+- **`networkSyncStore.ts`** — holds `GameServer` handle and drives ping/pong RTT (`handlePing` remote function, 3s interval, rolling 5-sample average with min/max trimmed).
+- **`effectStore.ts`** — `activeEffects` list + `effectKeyCounter`; `addEffect(type, sender, config)` / `removeEffect(key)`.
 
-### src/main.tsx
+## `src/hooks/`
 
-- Entry point for the application
-- Sets up React rendering
+- **`useNetworkSync.ts`** — standalone RTT hook (not wired in current flow; `networkSyncStore` is used instead).
 
-### src/App.tsx
+## `src/components/scene/` (flow screens + 3D host)
 
-- Main application component
-- Manages application flow between screens
-- Handles user authentication, room joining, and game state
+- **`NicknameSetup.tsx`** — nickname entry form; calls `onNicknameSet`.
+- **`RoomManager.tsx`** — create / join room UI; delegates to `onJoinRoom(roomId?)`.
+- **`LobbyRoom.tsx`** — character list from `Assets.characters`, per-user ready list via `useRoomAllUserStates`, inline `Canvas` preview using `CharacterPreview`; calls `setCharacter` / `toggleReady` remote functions.
+- **`GameScene.tsx`** — mounts R3F `Canvas` with `Physics`, hosts `Experience` + `NetworkContainer` + `EffectContainer`, and overlays the leave button, `RTT`, and room id.
 
-### src/assets.json
+## `src/components/r3f/` (inside `Canvas`)
 
-- Defines game assets (character models, animations)
-- Maps animation types to resource URLs
+- **`Experience.tsx`** — wraps `KeyboardControls` (from `controls.ts`), `Environment` preset, `SideViewController` (orthographic camera + follow light), the local `Player`, and `Floor`. Owns `spawnEffect` which adds locally via `useEffectStore` and broadcasts via `sendEffectEvent`. Writes `account` onto the local rigid-body's `userData` for self-hit filtering.
+- **`Player.tsx`** — local character: reads `useKeyboardControls`, runs state machine via `usePlayerStates` / `usePlayerAnimations`, drives `CharacterRenderer`, and throttles `updatePlayerTransform` (100ms + position/rotation/state dirty check). Magic key (`E`) triggers `FIREBALL` spawn via `spawnEffect`.
+- **`RemotePlayer.tsx`** — forwardRef exposing `RemotePlayerHandle.syncState`; renders `NetworkObject` + `CapsuleCollider` + `CharacterRenderer` + nickname `Billboard`. Collision groups set for kinematic-kinematic interaction.
+- **`NetworkContainer.tsx`** — subscribes to `subscribeRoomState` (prunes leavers) and `subscribeRoomAllUserStates` (adds newcomers and calls `syncState` every update). Only renders users that are ready and have a `transform` + `character`.
+- **`EffectContainer.tsx`** — reads `useActiveEffects`, renders `FireBallEffectController` / `Explosion`; subscribes to `onRoomMessage('effect-event', ...)` to mirror remote effects. Fireball self-hit is filtered by `rigidBody.userData.account`; a hit spawns a local `EXPLOSION` via `createExplosionEffectConfig`.
+- **`CharacterPreview.tsx`** — IDLE-only `CharacterRenderer` used by `LobbyRoom` for the selected-character thumbnail.
+- **`Floor.tsx`** — seeded random platform chain (15 blocks) driven by `roomId`; uses `RigidBody type="fixed"` + `CuboidCollider`.
+- **`effects/`** — `FireBall.tsx` (kinematic sensor with additive-blend mesh + trail flicker), `FireBallEffectController.tsx` (config builder + spawn gate), `Explosion.tsx` (instanced particle burst with fade).
 
-### src/types/
+## `src/components/ui/` (DOM overlay)
 
-- Contains TypeScript definitions for game entities
-- Includes player.ts, user.ts, and effect.ts for type safety
+- **`RTT.tsx`** — reads `networkSyncStore.rtt` and renders the ping badge used inside `GameScene`'s overlay.
 
-### src/constants/character.ts
+## `server.js` (agent8 gameserver)
 
-- Defines character states (idle, walk, run, etc.)
-- Provides enum values for animation system
-
-### src/constants/controls.ts
-
-- Defines keyboard control mappings
-- Sets up input configuration for player movement
-
-### src/store/networkSyncStore.ts
-
-- Zustand store for network state management
-- Handles RTT (Round Trip Time) calculation
-- Maintains connection with game server
-
-### src/store/effectStore.ts
-
-- Manages game effects like fireballs
-- Controls effect lifecycle and collision detection
-
-### src/components/scene/NicknameSetup.tsx
-
-- Component for setting user nickname
-- First screen in the game flow
-
-### src/components/scene/RoomManager.tsx
-
-- Interface for creating and joining game rooms
-- Displays available rooms and allows creation of new ones
-
-### src/components/scene/LobbyRoom.tsx
-
-- Pre-game lobby with character selection
-- Allows players to prepare before starting the game
-
-### src/components/scene/GameScene.tsx
-
-- Main game scene component
-- Sets up Canvas, Network and Experience components
-
-### src/components/r3f/Experience.tsx
-
-- Sets up 3D environment (physics, lighting, camera)
-- Configures core game elements
-- Connects side-view controller with player character
-
-### src/components/r3f/Player.tsx
-
-- Local player character with control logic
-- Handles animations, movement, and state transitions
-- Integrates network synchronization for remote players
-
-### src/components/r3f/RemotePlayer.tsx
-
-- Representation of other players in the game
-- Renders network-synchronized character models
-
-### src/components/r3f/NetworkContainer.tsx
-
-- Manages network-synchronized entities
-- Handles creation and removal of remote players
-- Subscribes to room state changes
-
-### src/components/r3f/Floor.tsx
-
-- Platform with physics properties
-- Seed-based random platform generation
-- Provides ground for character movement
-
-### src/components/r3f/EffectContainer.tsx
-
-- Container for visual effects like fireballs
-- Manages effect creation and lifecycle
-- Shares effects between players
-
-### src/components/ui/RTT.tsx
-
-- Displays network round-trip time
-- Provides feedback on connection quality
+Remote functions: `joinRoom`, `leaveRoom`, `setCharacter`, `toggleReady`, `updatePlayerTransform`, `sendMessage`, `sendEffectEvent`, `sendFireballEffect` (legacy), `handlePing`, `applyDamage`. `toggleReady` flips `roomState.gameStarted` on first ready; `$roomTick` is a stub.

--- a/basic-3d-sideview/PROJECT/Context.md
+++ b/basic-3d-sideview/PROJECT/Context.md
@@ -1,0 +1,26 @@
+# Context — basic-3d-sideview
+
+## Project Overview
+
+Three.js + React Three Fiber scaffold for a single-player 3D sideview scene. Camera is locked to a fixed side-on perspective via `SideViewController` (`cameraMode="perspective"`, `followCharacter={true}`, `camDistance={10}`), so movement reads as horizontal with jump/gravity even though the character and world are fully 3D. Player is built on `RigidBodyPlayer` with a humanoid animation set; the ground is a seed-based procedural strip of fixed `RigidBody` blocks with gaps for jumping. A two-phase boot (`PreloadScene` → `GameScene`) pulls every URL from `src/assets.json` before rendering, and `MapPhysicsReadyChecker` gates physics start via a downward raycast. Zustand stores are pre-split for multiplayer, and `@agent8/gameserver` is installed but no networking is wired.
+
+## Tech Stack
+
+_Exact versions are in `package.json`._
+
+- **Rendering**: Three.js, `@react-three/fiber`, `@react-three/drei`
+- **Physics**: `@react-three/rapier`
+- **Character framework**: `vibe-starter-3d` (`SideViewController`, `RigidBodyPlayer`, `CharacterRenderer`, `FollowLight`, `useCharacterAnimation`, `useControllerStore`, `useInputStore`)
+- **Multiplayer (unwired)**: `@agent8/gameserver`
+- **State**: Zustand
+- **Build / Lang**: Vite, TypeScript
+- **Styling**: Tailwind CSS
+
+## Critical Memory
+
+- Player must be built on `RigidBodyPlayer` and camera on `SideViewController`; the physics bootstrap depends on this pipeline.
+- Physics stay paused until `gameStore.isMapPhysicsReady` is `true`. `MapPhysicsReadyChecker` releases it via a downward raycast from `y=50` — new map geometry must be reachable by it (non-capsule, non-sensor).
+- `App.tsx` gates on `PreloadScene` first; every asset must be declared in `src/assets.json` or it will not be warm in the cache when `GameScene` mounts.
+- Side view is enforced by `SideViewController` parameters in `GameSceneCanvas.tsx` — do not swap it for another controller without reworking input and camera expectations.
+- Handle player collisions via `RigidBodyPlayer.onTriggerEnter` / `onTriggerExit`, switching on `RigidBodyObjectType` tags.
+- Character model and animation URLs are loaded via the `src/assets.json` manifest.

--- a/basic-3d-sideview/PROJECT/Requirements.md
+++ b/basic-3d-sideview/PROJECT/Requirements.md
@@ -1,0 +1,20 @@
+# Requirements — basic-3d-sideview
+
+## Coding Patterns
+
+- Stores are concern-split (Zustand): `gameStore`, `localPlayerStore`, `multiPlayerStore`, `playerActionStore` — do not cross-write. `playerActionStore` is a plain singleton exposed through a hook; mutate it only through `setPlayerAction` / `resetAllPlayerActions`.
+- R3F goes under `components/r3f/`, DOM under `components/ui/`; `GameScene.tsx` is a layout shell and must not render 3D directly or hold mutable state.
+- Extend `Player.tsx` by adding animation states to `CharacterState` and a matching entry in the `animationConfigMap`, not by forking the component.
+- Movement animation states come from `useControllerStore.getCharacterMovementState()` and pass through `toCharacterState` — combat states are pushed by `playerActionStore` with `lockControls()` / `unlockControls()` bracketing each one-shot.
+- Input writes go to `vibe-starter-3d`'s `useInputStore` (movement / jump) and `playerActionStore` (combat). Do not set controller state directly from UI.
+- Every renderable asset (models, animations, and anything you add) must be declared in `src/assets.json` so `PreloadScene` warms it.
+- No magic values — animation ids in `constants/character.ts`, rigid-body types in `constants/rigidBodyObjectType.ts`.
+
+## Known Issues / Constraints
+
+- Side view is enforced by the `SideViewController` parameters in `GameSceneCanvas.tsx`; changing `cameraMode`, `followCharacter`, or `camDistance` will break the intended perspective.
+- Keyboard/joystick bindings are hardcoded inside `InputController.tsx` (`CONTROL_KEY_MAPPING`, `ACTION_KEY_MAPPING`); there is no shared controls file to override.
+- `MapPhysicsReadyChecker` has a 180-frame raycast timeout — very slow map loads may expire it and start physics before geometry is detected.
+- `Floor` generates platforms along the x-axis only; world geometry off the z=0 strip must be added separately and still be reachable by the readiness raycast.
+- Mobile joystick hijacks the left 50% of the screen (`pointerEvents: auto`, `zIndex: 1000`) — do not place interactive DOM UI there.
+- `PreloadScene` onError only logs; a failed asset URL does not block completion, so broken URLs will surface at runtime in `Player` / scene mount.

--- a/basic-3d-sideview/PROJECT/Status.md
+++ b/basic-3d-sideview/PROJECT/Status.md
@@ -1,0 +1,21 @@
+# Status — basic-3d-sideview
+
+## Implemented
+
+- Fixed side-view camera (`SideViewController`, perspective, character-following, `camDistance={10}`)
+- Physics-based character controller (`RigidBodyPlayer`) with humanoid animation set (idle, idle_01, walk, run, fast_run, jump, punch, punch_01, kick, kick_01, kick_02, melee_attack, cast, hit, die)
+- Combat action state machine with control lock/unlock around one-shots (`playerActionStore` + `useControllerStore`)
+- Physics-ready bootstrap (`MapPhysicsReadyChecker` + in-game `LoadingScreen`)
+- Two-phase boot: `PreloadScene` warms every URL from `assets.json` through a shared `THREE.LoadingManager` before `GameScene` mounts
+- Seed-based procedural platform strip (`Floor.tsx`, default seed `12345`) with randomized width, depth, height, gap, and y-offset
+- Desktop input (keyboard WASD/arrows + Shift run + Space jump + F/G/Q/E and mouse buttons for combat) and mobile input (`nipplejs` joystick on left half + on-screen JUMP / ATTACK buttons)
+- Collision triggers via `RigidBodyPlayer.onTriggerEnter` / `onTriggerExit`
+- Scene lighting: ambient + `FollowLight` + sunset `Environment` preset (non-background)
+- Local-player position streaming into `localPlayerStore` with a squared-distance threshold
+
+## Installed but not wired
+
+- `@agent8/gameserver` — `useGameServer().account` is read for player registration, but no networking / session code ships
+- `@react-three/postprocessing` — no effect pipeline
+- `lucide-react` — no icon usage in the current UI
+- World geometry beyond the procedural floor strip — no walls, obstacles, items, or enemies despite the enums in `rigidBodyObjectType.ts`

--- a/basic-3d-sideview/PROJECT/Structure.md
+++ b/basic-3d-sideview/PROJECT/Structure.md
@@ -1,129 +1,46 @@
-# 3D Side View Game
+# Structure — basic-3d-sideview
 
-## Project Summary
+## `src/main.tsx`, `src/App.tsx`
 
-This project is a 3D platformer game with a side-scrolling perspective, similar to classic 2D platformers but with 3D graphics. Players control a character that can run, jump, and perform various actions while navigating through a procedurally generated terrain of platforms. The game features character animations, physics-based movement, and jump mechanics that are essential for platformer gameplay. This project is intended for single-player gameplay with an emphasis on platform jumping and character control.
+Entry point and root component. `App` owns a single `isLoading` flag that swaps `PreloadScene` for `GameScene` once every asset in `src/assets.json` is warm. Renders into a full-viewport container.
 
-## Implementation Strategy
+## `src/App.css`, `src/index.css`
 
-This game uses a **Three.js-based 3D approach**:
+Component styles and global base (Tailwind directives, fonts).
 
-- React Three Fiber for 3D rendering in a React environment
-- @react-three/rapier for physics simulation and collision detection
-- vibe-starter-3d library for character rendering and animation
-- Side view camera setup providing a classic platformer perspective
-- Seed-based procedural generation for platform layouts
+## `src/assets.json`
 
-Key technologies:
+Asset manifest — character model and animation URLs. Consumed by both `PreloadScene` (to warm the browser cache) and `Player` (to resolve animation URLs in the animation config map).
 
-- Three.js - 3D rendering
-- React Three Fiber - React integration
-- @react-three/rapier - Physics simulation
-- @react-three/drei - Useful Three.js helpers
-- vibe-starter-3d (v0.4.0) - Advanced character rendering, animation, and physics integration
-- Tailwind CSS - UI composition
-- Zustand - State management
+## `src/constants/`
 
-## Core Features
+- **`character.ts`** — animation state ids (idle, idle_01, walk, run, fast_run, jump, punch, punch_01, kick, kick_01, kick_02, melee_attack, cast, hit, die).
+- **`rigidBodyObjectType.ts`** — rigid-body category enum (local player, enemy, monster, wall, obstacle, item, bullet, floor, plotting board).
 
-- **Advanced Character System**: Comprehensive character rendering with physics-based rigid body integration
-- **Animation Management**: Complete animation system supporting idle, run, sprint, jump, punch, kick, normal_attack, cast, and other character states
-- **Physics Integration**: Full physics simulation with collision detection, gravity, and rigid body object type definitions
-- **Side View Camera**: Fixed side-view perspective with character following and configurable camera distance for optimal platformer experience
-- **Platformer Mechanics**: Specialized jumping mechanics and gravity-based movement essential for platformer gameplay
-- **Procedural Platform Generation**: Seed-based randomization system creating variable platform heights and gaps for challenging gameplay
-- **Interactive Controls**: Keyboard-based navigation (WASD for movement, QERF for actions) with mouse interaction support
-- **Environmental Collision**: Advanced collision detection system for platform interactions and environmental boundaries
-- **State Management**: Robust character state transitions and player reference tracking for multiplayer readiness
-- **Asset Management**: Comprehensive preloading system with progress indication for smooth gameplay
-- **3D Rendering**: High-quality 3D model rendering with smooth animation transitions optimized for platformer gameplay
+> Keyboard/mouse/touch bindings live inline in `InputController.tsx`; no shared `controls.ts` ships.
 
-## File Structure Overview
+## `src/stores/` (Zustand)
 
-### `src/main.tsx`
+- **`gameStore.ts`** — global lifecycle; holds `isMapPhysicsReady`.
+- **`localPlayerStore.ts`** — local-player state (position, speed).
+- **`multiPlayerStore.ts`** — registry of remote-player rigid-body refs.
+- **`playerActionStore.ts`** — combat action transitions (punch, kick, meleeAttack, cast). Implemented as a plain singleton object exposed through a hook, not `create()`.
 
-- Entry point for the application.
-- Sets up React rendering and mounts the `App` component.
+## `src/components/r3f/` (inside `Canvas`)
 
-### `src/App.tsx`
+- **`GameSceneCanvas.tsx`** — R3F `Canvas` root. Hosts Rapier `Physics` (paused until `isMapPhysicsReady`), `SideViewController` (`cameraMode="perspective"`, `followCharacter={true}`, `camDistance={10}`), `FollowLight`, and mounts `MapPhysicsReadyChecker` plus `Experience`.
+- **`Experience.tsx`** — in-canvas scene content: ambient light, sunset `Environment` (not used as background), `Player`, `Floor`.
+- **`MapPhysicsReadyChecker.tsx`** — raycasts downward each frame to detect map geometry; flips `isMapPhysicsReady` on hit or after a 180-frame timeout. Ignores capsules and sensor colliders.
+- **`Player.tsx`** — wraps `RigidBodyPlayer` + `CharacterRenderer`. Owns the animation config map, derives movement state via `useControllerStore.getCharacterMovementState()`, runs combat transitions from `playerActionStore`, lock/unlock controls around one-shot actions, and streams position into `localPlayerStore` with a squared-distance threshold.
+- **`Floor.tsx`** — seed-based procedural platform strip. Generates an initial wide block at the origin plus a run of fixed `RigidBody` blocks to the right and a shorter run to the left, with randomized width, depth, height, gap, and y-offset driven by a `SeededRandom` instance (default seed `12345`).
 
-- Main application component.
-- Configures the overall layout and includes the `GameScene` component.
-- Manages loading state and switches between `PreloadScene` and `GameScene`.
+## `src/components/scene/`
 
-### `src/App.css`
+- **`GameScene.tsx`** — layout shell stitching `GameSceneCanvas` (3D) and `GameSceneUI` (DOM overlay). Contains performance-critical warnings against mixing concerns.
+- **`PreloadScene.tsx`** — runs before `GameScene`. Iterates every category in `assets.json`, dispatches the right loader per extension (`GLTFLoader`, `TextureLoader`, `Audio`, `<video>`, `fetch` fallback) through a shared `THREE.LoadingManager`, and shows a percentage progress bar.
 
-- Defines the main styles for the `App` component and its child UI elements.
+## `src/components/ui/` (DOM overlay)
 
-### `src/index.css`
-
-- Defines global base styles, Tailwind CSS directives, fonts, etc., applied throughout the application.
-
-### `src/assets.json`
-
-- File for managing asset metadata. Includes character model and animation information.
-
-### `src/stores/`
-
-- Directory containing state management stores using Zustand.
-  - **`gameStore.ts`**: Store that manages the overall game state. Tracks and controls the readiness state of the map physics system (`isMapPhysicsReady`). This state is used to determine physics simulation pause/resume and loading screen display.
-  - **`localPlayerStore.ts`**: Store that manages the local player's state, such as position tracking.
-  - **`multiPlayerStore.ts`**: Store that manages multiple connected players' rigid body references for multiplayer functionality, including registration, unregistration, and retrieval of player references.
-  - **`playerActionStore.ts`**: Store that manages player action states including combat actions (punch, kick, meleeAttack, cast) with support for setting, getting, and resetting action states.
-
-### `src/constants/`
-
-- Directory defining constant values used throughout the application.
-  - **`controls.ts`**: Defines settings that map keyboard inputs (WASD, arrow keys, etc.) to corresponding actions (movement, jump, etc.).
-  - **`character.ts`**: Defines character-related constants (animation states, speed, etc.).
-  - **`rigidBodyObjectType.ts`**: Defines physics object types for collision detection and interaction systems.
-
-### Components
-
-### `src/components/`
-
-- Directory managing React components categorized by function.
-
-  - **`r3f/`**: Contains 3D components related to React Three Fiber.
-
-    - **`Experience.tsx`**: Main component responsible for the primary 3D scene configuration. Includes lighting `ambientLight`, environmental elements `Environment`, the `Player` component, and the floor `Floor`. It renders the core visual and interactive elements within the physics simulation configured in `GameScene.tsx`.
-    - **`Floor.tsx`**: Component defining and visually representing the ground plane in the 3D space. Has physical properties and implements procedurally generated platforms for the platformer gameplay.
-    - **`GameSceneCanvas.tsx`**: React Three Fiber Canvas component that renders the 3D game world with physics simulation and controller setup.
-    - **`MapPhysicsReadyChecker.tsx`**: Component that checks if the map physics system is ready by performing raycasting from above downward to detect map geometry and ensures physics interactions are properly initialized before gameplay begins. Performs checks every frame until valid map geometry is detected, with a timeout after 180 frames to prevent infinite checking. Excludes Capsule shapes (likely characters/objects) and sensor colliders from the inspection.
-    - **`Player.tsx`**: Advanced player component integrating RigidBodyPlayer with CharacterRenderer for comprehensive character management, physics interactions, and animation state management with collision detection capabilities optimized for platformer gameplay.
-
-  - **`scene/`**: Contains components related to scene setup.
-
-    - **`GameScene.tsx`**: Main game scene component that serves as a layout container arranging the game UI and 3D Canvas. Contains critical performance warnings and guidelines to prevent re-rendering issues. Includes the `GameSceneCanvas` and `GameSceneUI` components in a proper layered structure where the Canvas renders the 3D world and UI components render as overlays.
-    - **`PreloadScene.tsx`**: Manages asset preloading before the game starts. Loads all assets defined in assets.json (models, textures, etc.) and displays a loading progress bar. Ensures all assets are loaded before the game begins.
-
-  - **`ui/`**: Contains UI components for the game interface.
-    - **`GameSceneUI.tsx`**: Component that manages UI overlays for the game scene.
-    - **`LoadingScreen.tsx`**: Loading screen component displayed during game loading.
-    - **`InputController.tsx`**: Manages all input handling including keyboard, mouse, and touch controls with virtual joystick support for mobile devices and action buttons for combat actions (punch, kick, cast) and movement controls.
-
-### Key Libraries & Components from External Sources
-
-- **`vibe-starter-3d`**: A library providing foundational 3D game components and utilities.
-  - **`SideViewController`**: Wraps the player character and manages side view navigation by implementing a character controller with physics. It handles character movement, jumping mechanics, and camera following with a fixed side-view perspective.
-  - **`CharacterRenderer`**: Renders 3D character models with animations from glTF/GLB files. Manages animation states and transitions based on player actions.
-  - **`useControllerState`**: A React hook that provides control state management for the character, including:
-    - `setEnableInput`: Function to enable/disable player input controls
-    - `rigidBody`: Reference to the physics body for the character
-  - **`useMouseControls`**: A React hook that provides access to mouse input state (left/right buttons and positions).
-
-### Side View System Implementation
-
-The side view platformer system is implemented through a combination of components:
-
-1. **Controller System**: `SideViewController` from the vibe-starter-3d library handles the physics-based movement of the character based on keyboard inputs, implementing platformer mechanics like jumping and gravity with a fixed camera angle that provides the side view perspective and configurable camera distance.
-
-2. **Input Management**: Keyboard inputs are captured through React Three Fiber's `useKeyboardControls` hook, which maps WASD/arrow keys to movement actions (with special emphasis on jump controls essential for platformer gameplay), with mouse controls for additional interactions.
-
-3. **State Management**: `useControllerState` hook provides shared state between components, allowing different parts of the application to access and modify the character's state. Additionally, `playerStore` manages physics body references for multiplayer support.
-
-4. **Animation Management**: `Player` component with `RigidBodyPlayer` integration determines appropriate animations based on movement and action states, with special attention to jump, fall, and landing animations essential for platformer games, including full collision detection capabilities.
-
-5. **Platform Generation**: Procedurally generated platforms create the game environment, with varying heights and distances to create challenging platforming gameplay.
-
-6. **Asset Management**: `PreloadScene` component ensures all 3D models, textures, and other assets are preloaded before gameplay begins, providing a smooth user experience with a visual loading indicator.
+- **`GameSceneUI.tsx`** — UI overlay container; mounts `InputController` and the in-game `LoadingScreen` while `isMapPhysicsReady` is `false`.
+- **`LoadingScreen.tsx`** — spinner + label. Self-detects whether it is mounted inside the R3F `Canvas` and wraps itself in `<Html>` if so.
+- **`InputController.tsx`** — keyboard + mouse + touch. Writes movement/action into `vibe-starter-3d`'s `useInputStore` and combat transitions into `playerActionStore`. On mobile, spawns an `nipplejs` virtual joystick on the left half of the screen and renders on-screen JUMP and ATTACK buttons.

--- a/basic-3d/PROJECT/Context.md
+++ b/basic-3d/PROJECT/Context.md
@@ -1,0 +1,22 @@
+# Context — basic-3d
+
+## Project Overview
+
+Minimal Vite + React + TypeScript scaffold with Three.js / React Three Fiber and Rapier pre-installed as dependencies. `src/` currently ships only a default `App.tsx` counter component — no `Canvas`, no scene, no stores, no physics are wired. This is a bare starting point for building a 3D app from scratch against a fixed dependency baseline.
+
+## Tech Stack
+
+_Exact versions are in `package.json`._
+
+- **Rendering (installed)**: Three.js, `@react-three/fiber`, `@react-three/drei`
+- **Physics (installed)**: `@react-three/rapier`, `@dimforge/rapier3d-compat`
+- **Post-processing (installed)**: `@react-three/postprocessing`
+- **Multiplayer (installed)**: `@agent8/gameserver`
+- **State (installed)**: Zustand
+- **Icons (installed)**: `lucide-react`
+- **Build / Lang**: Vite, TypeScript
+- **Styling**: Tailwind CSS
+
+## Critical Memory
+
+- No template-specific runtime invariants. `src/` has no 3D code yet — adopt patterns from sibling `basic-3d-*` templates when introducing a `Canvas`, physics, or stores.

--- a/basic-3d/PROJECT/Requirements.md
+++ b/basic-3d/PROJECT/Requirements.md
@@ -1,0 +1,13 @@
+# Requirements — basic-3d
+
+## Coding Patterns
+
+- Keep the dependency baseline in `package.json` intact; add new code against the already-installed libraries before introducing new ones.
+- Register image/model/animation URLs in `src/assets.json` instead of hard-coding paths.
+- Use Tailwind utility classes (already wired via `index.css`) for styling; avoid ad-hoc global CSS.
+
+## Known Issues / Constraints
+
+- No 3D scene, `Canvas`, stores, or physics bootstrap exist yet — adding any of these requires wiring from scratch.
+- `vibe-starter-3d` is **not** installed; character-controller helpers used by sibling templates (`RigidBodyPlayer`, `FreeViewController`, etc.) are unavailable unless added explicitly.
+- `index.html` posts `GAME_SIZE_RESPONSE` messages to `window.parent`; preserve this handler when hosting inside an iframe.

--- a/basic-3d/PROJECT/Status.md
+++ b/basic-3d/PROJECT/Status.md
@@ -1,0 +1,19 @@
+# Status — basic-3d
+
+## Implemented
+
+- Vite + React 18 + TypeScript scaffold
+- Tailwind CSS pipeline (`index.css` directives, `tailwind.config.js`, `postcss.config.js`)
+- ESLint configuration
+- Default `App.tsx` counter component
+- `index.html` iframe size reporter (`GAME_SIZE_RESPONSE` via `postMessage`)
+- Empty `assets.json` manifest
+
+## Installed but not wired
+
+- `three`, `@react-three/fiber`, `@react-three/drei` — no `Canvas` or scene
+- `@react-three/rapier`, `@dimforge/rapier3d-compat` — no physics world
+- `@react-three/postprocessing` — no effect pipeline
+- `zustand` — no stores
+- `@agent8/gameserver` — no networking / session code
+- `lucide-react` — no icons used

--- a/basic-3d/PROJECT/Structure.md
+++ b/basic-3d/PROJECT/Structure.md
@@ -1,0 +1,25 @@
+# Structure — basic-3d
+
+## `src/main.tsx`
+
+Entry point. Mounts `<App />` into `#root` inside `StrictMode`.
+
+## `src/App.tsx`
+
+Root component. Renders a full-viewport container with a single Tailwind-styled counter button. No 3D content.
+
+## `src/App.css`, `src/index.css`
+
+`index.css` holds Tailwind directives (`@tailwind base/components/utilities`); `App.css` contains a minimal `#root` rule.
+
+## `src/assets.json`
+
+Asset manifest. Currently `{ "images": {} }` — empty.
+
+## `src/vite-env.d.ts`
+
+Vite client type reference.
+
+## `index.html`
+
+HTML shell. Includes an inline loading spinner and a `postMessage`-based `GAME_SIZE_RESPONSE` reporter that posts document dimensions to `window.parent` on load, resize, and `REQUEST_GAME_SIZE`.

--- a/basic-vite-react/PROJECT/Context.md
+++ b/basic-vite-react/PROJECT/Context.md
@@ -1,0 +1,19 @@
+# Context — basic-vite-react
+
+## Project Overview
+
+Minimal React + TypeScript scaffold built with Vite and Tailwind CSS. `App.tsx` renders a single counter button wired to `useState`; `main.tsx` mounts it with `createRoot` under `StrictMode`. No 3D, no game engine, no networking — this is the baseline that every other template in the repo is derived from.
+
+## Tech Stack
+
+_Exact versions are in `package.json`._
+
+- **Framework**: React, React DOM
+- **Build / Lang**: Vite, TypeScript
+- **Styling**: Tailwind CSS, PostCSS (autoprefixer)
+- **Icons**: `lucide-react`
+- **Multiplayer (unwired)**: `@agent8/gameserver`
+
+## Critical Memory
+
+No template-specific runtime invariants. Standard React + Vite conventions apply.

--- a/basic-vite-react/PROJECT/Requirements.md
+++ b/basic-vite-react/PROJECT/Requirements.md
@@ -1,0 +1,12 @@
+# Requirements — basic-vite-react
+
+## Coding Patterns
+
+- Function components with hooks; no class components.
+- Style via Tailwind utility classes in JSX; keep custom CSS minimal and scoped (`App.css` for component, `index.css` for globals/Tailwind directives).
+- Register new image/asset URLs under `src/assets.json` rather than hardcoding.
+
+## Known Issues / Constraints
+
+- Baseline template — no routing, no state management library, no networking layer wired up.
+- `@agent8/gameserver` and `lucide-react` are installed but not imported anywhere.

--- a/basic-vite-react/PROJECT/Status.md
+++ b/basic-vite-react/PROJECT/Status.md
@@ -1,0 +1,13 @@
+# Status — basic-vite-react
+
+## Implemented
+
+- React 18 root mount with `StrictMode` (`main.tsx`)
+- Counter demo component with `useState` (`App.tsx`)
+- Tailwind CSS pipeline (directives in `index.css`, PostCSS + autoprefixer)
+- Empty asset manifest (`src/assets.json`)
+
+## Installed but not wired
+
+- `@agent8/gameserver` — no networking / session code
+- `lucide-react` — no icons imported

--- a/basic-vite-react/PROJECT/Structure.md
+++ b/basic-vite-react/PROJECT/Structure.md
@@ -1,32 +1,21 @@
-# [PROJECT TITLE]
+# Structure — basic-vite-react
 
-## Project Summary
+## `src/main.tsx`
 
-[THIS IS TEMPLATE PROJECT, PLEASE UPDATE HERE]
+Entry point. Mounts `<App />` into `#root` via `createRoot`, wrapped in `StrictMode`. Imports `index.css`.
 
-## Implementation Strategy
+## `src/App.tsx`
 
-- [THIS IS TEMPLATE PROJECT, PLEASE UPDATE HERE]
+Root component. Renders a single counter button styled with Tailwind utility classes.
 
-## Implemented Features
+## `src/App.css`
 
-- [THIS IS TEMPLATE PROJECT, PLEASE UPDATE HERE]
+Component-scoped styles for `App` (root layout: max-width, centered, padded).
 
-## File Structure Overview
+## `src/index.css`
 
-### src/main.tsx
+Global stylesheet — Tailwind `base`, `components`, `utilities` directives only.
 
-- Entry point for the application
-- Sets up React rendering with React 18's createRoot API
-- Imports and applies global CSS
+## `src/assets.json`
 
-### src/App.tsx
-
-- Root component of the application
-- Demonstrates basic React component structure
-- Shows how to handle state and events in a React component
-
-### src/App.css
-
-- Contains component-specific styles for the App component
-- Demonstrates how to use component-scoped CSS
+Asset manifest. Empty (`{ "images": {} }`) in the baseline template.


### PR DESCRIPTION
## Summary

Adds `PROJECT/*.md` documentation to every template in the repo so the downstream agent workflow (which expects `PROJECT/Context.md`, `PROJECT/Structure.md`, `PROJECT/Requirements.md`, `PROJECT/Status.md` under each project root) has real content to read.

Each template now ships with four files under `PROJECT/`, with non-overlapping roles:

- **Context.md** — project overview, tech stack, critical runtime invariants
- **Structure.md** — file and directory layout
- **Requirements.md** — coding patterns, known issues and constraints
- **Status.md** — implemented features and installed-but-not-wired items

### Scope

- **17 templates** covered: `basic-vite-react`, `basic-2d`, `basic-3d`, `2d-phaser-basic`, `2d-phaser-sprite-character-gravity`, and all `basic-3d-*` (freeview / firstpersonview / flightview / quarterview / sideview / minecraft, each in single and multiplay variants).
- **2 templates** (`basic-2d`, `basic-3d`) had no `PROJECT/` directory; created from scratch.
- **15 templates** had a legacy `Structure.md`; replaced with a layout-only version (the old `Project Summary` / `Implementation Strategy` / `Implemented Features` sections are removed because those roles now live in the three new files).

### Conventions

- All docs are written in English.
- Tech Stack omits concrete version numbers — `package.json` remains the single source of truth.
- No emojis, no marketing phrasing (`production-ready`, `ideal for`, `solid baseline`, etc.).
- `Project Overview` focuses on what is currently implemented, not what the template is "good for", because the agent has already picked the template by the time it reads this file.

## Test plan

- [x] Spot-check a representative 3D template (e.g. `basic-3d-freeview`) and a 2D one (`2d-phaser-basic`) — confirm each `PROJECT/*.md` reflects the real code.
- [x] Verify every template directory has exactly four files under `PROJECT/`.
- [x] Confirm no remaining emojis or hardcoded version numbers in `PROJECT/` docs.
- [x] Agent run against one template downstream picks up the new docs without errors.

Refs #75, Closes #76 