### PR TITLE
perf: disable reportCompressedSize in all template vite configs

### DIFF
--- a/2d-phaser-basic/vite.config.ts
+++ b/2d-phaser-basic/vite.config.ts
@@ -10,5 +10,8 @@ export default defineConfig({
   base: "./",
   build: {
     outDir: "dist",
+    // Skip gzip-size reporting: our users don't optimize by bundle size,
+    // and it only slows the build. Output is byte-identical.
+    reportCompressedSize: false,
   },
 });

--- a/2d-phaser-sprite-character-gravity/vite.config.ts
+++ b/2d-phaser-sprite-character-gravity/vite.config.ts
@@ -10,5 +10,8 @@ export default defineConfig({
   base: "./",
   build: {
     outDir: "dist",
+    // Skip gzip-size reporting: our users don't optimize by bundle size,
+    // and it only slows the build. Output is byte-identical.
+    reportCompressedSize: false,
   },
 });

--- a/basic-2d/vite.config.ts
+++ b/basic-2d/vite.config.ts
@@ -10,5 +10,8 @@ export default defineConfig({
   base: "./",
   build: {
     outDir: "dist",
+    // Skip gzip-size reporting: our users don't optimize by bundle size,
+    // and it only slows the build. Output is byte-identical.
+    reportCompressedSize: false,
   },
 });

--- a/basic-3d-firstpersonview-multiplay/vite.config.ts
+++ b/basic-3d-firstpersonview-multiplay/vite.config.ts
@@ -10,5 +10,8 @@ export default defineConfig({
   base: "./",
   build: {
     outDir: "dist",
+    // Skip gzip-size reporting: our users don't optimize by bundle size,
+    // and it only slows the build. Output is byte-identical.
+    reportCompressedSize: false,
   },
 });

--- a/basic-3d-firstpersonview/vite.config.ts
+++ b/basic-3d-firstpersonview/vite.config.ts
@@ -10,5 +10,8 @@ export default defineConfig({
   base: "./",
   build: {
     outDir: "dist",
+    // Skip gzip-size reporting: our users don't optimize by bundle size,
+    // and it only slows the build. Output is byte-identical.
+    reportCompressedSize: false,
   },
 });

--- a/basic-3d-flightview-multiplay/vite.config.ts
+++ b/basic-3d-flightview-multiplay/vite.config.ts
@@ -10,5 +10,8 @@ export default defineConfig({
   base: "./",
   build: {
     outDir: "dist",
+    // Skip gzip-size reporting: our users don't optimize by bundle size,
+    // and it only slows the build. Output is byte-identical.
+    reportCompressedSize: false,
   },
 });

--- a/basic-3d-flightview/vite.config.ts
+++ b/basic-3d-flightview/vite.config.ts
@@ -10,5 +10,8 @@ export default defineConfig({
   base: "./",
   build: {
     outDir: "dist",
+    // Skip gzip-size reporting: our users don't optimize by bundle size,
+    // and it only slows the build. Output is byte-identical.
+    reportCompressedSize: false,
   },
 });

--- a/basic-3d-freeview-multiplay/vite.config.ts
+++ b/basic-3d-freeview-multiplay/vite.config.ts
@@ -10,5 +10,8 @@ export default defineConfig({
   base: "./",
   build: {
     outDir: "dist",
+    // Skip gzip-size reporting: our users don't optimize by bundle size,
+    // and it only slows the build. Output is byte-identical.
+    reportCompressedSize: false,
   },
 });

--- a/basic-3d-freeview/vite.config.ts
+++ b/basic-3d-freeview/vite.config.ts
@@ -10,5 +10,8 @@ export default defineConfig({
   base: "./",
   build: {
     outDir: "dist",
+    // Skip gzip-size reporting: our users don't optimize by bundle size,
+    // and it only slows the build. Output is byte-identical.
+    reportCompressedSize: false,
   },
 });

--- a/basic-3d-minecraft-multiplay/vite.config.ts
+++ b/basic-3d-minecraft-multiplay/vite.config.ts
@@ -10,5 +10,8 @@ export default defineConfig({
   base: "./",
   build: {
     outDir: "dist",
+    // Skip gzip-size reporting: our users don't optimize by bundle size,
+    // and it only slows the build. Output is byte-identical.
+    reportCompressedSize: false,
   },
 });

--- a/basic-3d-minecraft/vite.config.ts
+++ b/basic-3d-minecraft/vite.config.ts
@@ -10,5 +10,8 @@ export default defineConfig({
   base: "./",
   build: {
     outDir: "dist",
+    // Skip gzip-size reporting: our users don't optimize by bundle size,
+    // and it only slows the build. Output is byte-identical.
+    reportCompressedSize: false,
   },
 });

--- a/basic-3d-quarterview-multiplay/vite.config.ts
+++ b/basic-3d-quarterview-multiplay/vite.config.ts
@@ -10,5 +10,8 @@ export default defineConfig({
   base: "./",
   build: {
     outDir: "dist",
+    // Skip gzip-size reporting: our users don't optimize by bundle size,
+    // and it only slows the build. Output is byte-identical.
+    reportCompressedSize: false,
   },
 });

--- a/basic-3d-quarterview/vite.config.ts
+++ b/basic-3d-quarterview/vite.config.ts
@@ -10,5 +10,8 @@ export default defineConfig({
   base: "./",
   build: {
     outDir: "dist",
+    // Skip gzip-size reporting: our users don't optimize by bundle size,
+    // and it only slows the build. Output is byte-identical.
+    reportCompressedSize: false,
   },
 });

--- a/basic-3d-sideview-multiplay/vite.config.ts
+++ b/basic-3d-sideview-multiplay/vite.config.ts
@@ -10,5 +10,8 @@ export default defineConfig({
   base: "./",
   build: {
     outDir: "dist",
+    // Skip gzip-size reporting: our users don't optimize by bundle size,
+    // and it only slows the build. Output is byte-identical.
+    reportCompressedSize: false,
   },
 });

--- a/basic-3d-sideview/vite.config.ts
+++ b/basic-3d-sideview/vite.config.ts
@@ -10,5 +10,8 @@ export default defineConfig({
   base: "./",
   build: {
     outDir: "dist",
+    // Skip gzip-size reporting: our users don't optimize by bundle size,
+    // and it only slows the build. Output is byte-identical.
+    reportCompressedSize: false,
   },
 });

--- a/basic-3d/vite.config.ts
+++ b/basic-3d/vite.config.ts
@@ -10,5 +10,8 @@ export default defineConfig({
   base: "./",
   build: {
     outDir: "dist",
+    // Skip gzip-size reporting: our users don't optimize by bundle size,
+    // and it only slows the build. Output is byte-identical.
+    reportCompressedSize: false,
   },
 });

--- a/basic-vite-react/vite.config.ts
+++ b/basic-vite-react/vite.config.ts
@@ -10,5 +10,8 @@ export default defineConfig({
   base: "./",
   build: {
     outDir: "dist",
+    // Skip gzip-size reporting: our users don't optimize by bundle size,
+    // and it only slows the build. Output is byte-identical.
+    reportCompressedSize: false,
   },
 });


### PR DESCRIPTION
## 배경

vite는 빌드가 끝날 때마다 생성된 **모든 청크를 gzip 압축해서** 요약 로그에 `gzip: N kB` 컬럼을 찍습니다. agent8 사용자는 바이브코딩으로 게임을 만드는 사람들이라 **번들 크기를 이 숫자 보고 최적화하는 워크플로가 없고**(로그도 iframe 너머라 잘 안 봄), 그 계산은 매 빌드를 느리게만 합니다.

## 변경

전 템플릿(17개) vite.config.ts의 build 블록에 `reportCompressedSize: false` 추가.

```ts
build: {
  outDir: "dist",
  reportCompressedSize: false,  // 추가
},
```

## 효과·리스크

- **효과**: 빌드 시간 단축. 스테이징 컨테이너 실측(three+phaser+@react-three 전체 import한 무거운 3D 스택)에서 약 8% (26s→23s). 청크가 더 많은 대형 프로젝트일수록 큼.
- **산출물 무변화**: dist 파일은 **바이트 하나 안 달라집니다.** 빌드 로그에서 `gzip: N kB` 표기만 사라짐. 배포 안전성 리스크 0.
- **적용 범위**: 신규 생성 프로젝트부터. 기존 프로젝트는 각자 config가 이미 복사돼 있어 미적용(swap이 메모리는 이미 방어 중이라 소급 불필요).

17개 config가 변경 전/후 모두 바이트 단위로 동일함을 해시로 확인했고, 전부 esbuild 트랜스파일 통과했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)