### PR TITLE
feat: upgrade all templates to vite 8 (rolldown)

### DIFF
--- a/2d-phaser-basic/package.json
+++ b/2d-phaser-basic/package.json
@@ -19,11 +19,11 @@
   "devDependencies": {
     "@types/react": "^18.2.33",
     "@types/react-dom": "^18.2.11",
-    "@vitejs/plugin-react": "^4.3.4",
+    "@vitejs/plugin-react": "^6.0.3",
     "globals": "^15.15.0",
     "tailwindcss": "^3.4.1",
     "autoprefixer": "^10.4.18",
     "typescript": "~5.7.2",
-    "vite": "^6.2.0"
+    "vite": "^8.1.4"
   }
 }

--- a/2d-phaser-sprite-character-gravity/package.json
+++ b/2d-phaser-sprite-character-gravity/package.json
@@ -19,11 +19,11 @@
   "devDependencies": {
     "@types/react": "^18.2.33",
     "@types/react-dom": "^18.2.11",
-    "@vitejs/plugin-react": "^4.3.4",
+    "@vitejs/plugin-react": "^6.0.3",
     "globals": "^15.15.0",
     "tailwindcss": "^3.4.1",
     "autoprefixer": "^10.4.18",
     "typescript": "~5.7.2",
-    "vite": "^6.2.0"
+    "vite": "^8.1.4"
   }
 }

--- a/basic-2d/package.json
+++ b/basic-2d/package.json
@@ -18,12 +18,12 @@
   "devDependencies": {
     "@types/react": "^18.2.33",
     "@types/react-dom": "^18.2.11",
-    "@vitejs/plugin-react": "^4.3.4",
+    "@vitejs/plugin-react": "^6.0.3",
     "globals": "^15.15.0",
     "tailwindcss": "^3.4.1",
     "autoprefixer": "^10.4.18",
     "typescript": "~5.7.2",
     "typescript-eslint": "^8.24.1",
-    "vite": "^6.2.0"
+    "vite": "^8.1.4"
   }
 }

--- a/basic-3d-firstpersonview-multiplay/package.json
+++ b/basic-3d-firstpersonview-multiplay/package.json
@@ -28,7 +28,7 @@
     "@types/react": "^18.3.20",
     "@types/react-dom": "^18.3.5",
     "@types/three": "^0.174.0",
-    "@vitejs/plugin-react": "^4.3.4",
+    "@vitejs/plugin-react": "^6.0.3",
     "autoprefixer": "^10.4.21",
     "eslint": "^9.23.0",
     "eslint-plugin-react-hooks": "^5.2.0",
@@ -37,6 +37,6 @@
     "tailwindcss": "^3.4.17",
     "typescript": "~5.8.2",
     "typescript-eslint": "^8.28.0",
-    "vite": "^6.2.3"
+    "vite": "^8.1.4"
   }
 }

--- a/basic-3d-firstpersonview/package.json
+++ b/basic-3d-firstpersonview/package.json
@@ -30,7 +30,7 @@
     "@types/react": "^18.3.20",
     "@types/react-dom": "^18.3.5",
     "@types/three": "^0.174.0",
-    "@vitejs/plugin-react": "^4.3.4",
+    "@vitejs/plugin-react": "^6.0.3",
     "autoprefixer": "^10.4.21",
     "eslint": "^9.23.0",
     "eslint-plugin-react-hooks": "^5.2.0",
@@ -39,6 +39,6 @@
     "tailwindcss": "^3.4.17",
     "typescript": "~5.8.2",
     "typescript-eslint": "^8.28.0",
-    "vite": "^6.2.3"
+    "vite": "^8.1.4"
   }
 }

--- a/basic-3d-flightview-multiplay/package.json
+++ b/basic-3d-flightview-multiplay/package.json
@@ -28,7 +28,7 @@
     "@types/react": "^18.3.20",
     "@types/react-dom": "^18.3.5",
     "@types/three": "^0.174.0",
-    "@vitejs/plugin-react": "^4.3.4",
+    "@vitejs/plugin-react": "^6.0.3",
     "autoprefixer": "^10.4.21",
     "eslint": "^9.23.0",
     "eslint-plugin-react-hooks": "^5.2.0",
@@ -37,6 +37,6 @@
     "tailwindcss": "^3.4.17",
     "typescript": "~5.8.2",
     "typescript-eslint": "^8.28.0",
-    "vite": "^6.2.3"
+    "vite": "^8.1.4"
   }
 }

--- a/basic-3d-flightview/package.json
+++ b/basic-3d-flightview/package.json
@@ -29,7 +29,7 @@
     "@types/react": "^18.3.20",
     "@types/react-dom": "^18.3.5",
     "@types/three": "^0.174.0",
-    "@vitejs/plugin-react": "^4.3.4",
+    "@vitejs/plugin-react": "^6.0.3",
     "autoprefixer": "^10.4.21",
     "eslint": "^9.23.0",
     "eslint-plugin-react-hooks": "^5.2.0",
@@ -38,6 +38,6 @@
     "tailwindcss": "^3.4.17",
     "typescript": "~5.8.2",
     "typescript-eslint": "^8.28.0",
-    "vite": "^6.2.3"
+    "vite": "^8.1.4"
   }
 }

--- a/basic-3d-freeview-multiplay/package.json
+++ b/basic-3d-freeview-multiplay/package.json
@@ -29,11 +29,11 @@
     "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.1",
     "@types/three": "^0.174.0",
-    "@vitejs/plugin-react": "^4.3.4",
+    "@vitejs/plugin-react": "^6.0.3",
     "autoprefixer": "^10.4.21",
     "globals": "^16.0.0",
     "tailwindcss": "^3.4.1",
     "typescript": "~5.8.2",
-    "vite": "^6.2.2"
+    "vite": "^8.1.4"
   }
 }

--- a/basic-3d-freeview/package.json
+++ b/basic-3d-freeview/package.json
@@ -30,7 +30,7 @@
     "@types/react": "^18.3.20",
     "@types/react-dom": "^18.3.5",
     "@types/three": "^0.174.0",
-    "@vitejs/plugin-react": "^4.3.4",
+    "@vitejs/plugin-react": "^6.0.3",
     "autoprefixer": "^10.4.21",
     "eslint": "^9.23.0",
     "eslint-plugin-react-hooks": "^5.2.0",
@@ -39,6 +39,6 @@
     "tailwindcss": "^3.4.17",
     "typescript": "~5.8.2",
     "typescript-eslint": "^8.28.0",
-    "vite": "^6.2.3"
+    "vite": "^8.1.4"
   }
 }

--- a/basic-3d-minecraft-multiplay/package.json
+++ b/basic-3d-minecraft-multiplay/package.json
@@ -31,11 +31,11 @@
     "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.1",
     "@types/three": "^0.174.0",
-    "@vitejs/plugin-react": "^4.3.4",
+    "@vitejs/plugin-react": "^6.0.3",
     "autoprefixer": "^10.4.21",
     "globals": "^16.0.0",
     "tailwindcss": "^3.4.1",
     "typescript": "~5.8.2",
-    "vite": "^6.2.2"
+    "vite": "^8.1.4"
   }
 }

--- a/basic-3d-minecraft/package.json
+++ b/basic-3d-minecraft/package.json
@@ -32,11 +32,11 @@
     "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.1",
     "@types/three": "^0.174.0",
-    "@vitejs/plugin-react": "^4.3.4",
+    "@vitejs/plugin-react": "^6.0.3",
     "autoprefixer": "^10.4.21",
     "globals": "^16.0.0",
     "tailwindcss": "^3.4.1",
     "typescript": "~5.8.2",
-    "vite": "^6.2.2"
+    "vite": "^8.1.4"
   }
 }

--- a/basic-3d-quarterview-multiplay/package.json
+++ b/basic-3d-quarterview-multiplay/package.json
@@ -29,11 +29,11 @@
     "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.1",
     "@types/three": "^0.174.0",
-    "@vitejs/plugin-react": "^4.3.4",
+    "@vitejs/plugin-react": "^6.0.3",
     "autoprefixer": "^10.4.21",
     "globals": "^16.0.0",
     "tailwindcss": "^3.4.1",
     "typescript": "~5.8.2",
-    "vite": "^6.2.2"
+    "vite": "^8.1.4"
   }
 }

--- a/basic-3d-quarterview/package.json
+++ b/basic-3d-quarterview/package.json
@@ -29,11 +29,11 @@
     "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.1",
     "@types/three": "^0.174.0",
-    "@vitejs/plugin-react": "^4.3.4",
+    "@vitejs/plugin-react": "^6.0.3",
     "autoprefixer": "^10.4.21",
     "globals": "^16.0.0",
     "tailwindcss": "^3.4.1",
     "typescript": "~5.8.2",
-    "vite": "^6.2.2"
+    "vite": "^8.1.4"
   }
 }

--- a/basic-3d-sideview-multiplay/package.json
+++ b/basic-3d-sideview-multiplay/package.json
@@ -29,11 +29,11 @@
     "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.1",
     "@types/three": "^0.174.0",
-    "@vitejs/plugin-react": "^4.3.4",
+    "@vitejs/plugin-react": "^6.0.3",
     "autoprefixer": "^10.4.21",
     "globals": "^16.0.0",
     "tailwindcss": "^3.4.1",
     "typescript": "~5.8.2",
-    "vite": "^6.2.2"
+    "vite": "^8.1.4"
   }
 }

--- a/basic-3d-sideview/package.json
+++ b/basic-3d-sideview/package.json
@@ -29,11 +29,11 @@
     "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.1",
     "@types/three": "^0.174.0",
-    "@vitejs/plugin-react": "^4.3.4",
+    "@vitejs/plugin-react": "^6.0.3",
     "autoprefixer": "^10.4.21",
     "globals": "^16.0.0",
     "tailwindcss": "^3.4.1",
     "typescript": "~5.8.2",
-    "vite": "^6.2.2"
+    "vite": "^8.1.4"
   }
 }

--- a/basic-3d/package.json
+++ b/basic-3d/package.json
@@ -27,7 +27,7 @@
     "@types/react": "^18.3.20",
     "@types/react-dom": "^18.3.5",
     "@types/three": "^0.174.0",
-    "@vitejs/plugin-react": "^4.3.4",
+    "@vitejs/plugin-react": "^6.0.3",
     "autoprefixer": "^10.4.21",
     "eslint": "^9.23.0",
     "eslint-plugin-react-hooks": "^5.2.0",
@@ -36,6 +36,6 @@
     "tailwindcss": "^3.4.17",
     "typescript": "~5.8.2",
     "typescript-eslint": "^8.28.0",
-    "vite": "^6.2.3"
+    "vite": "^8.1.4"
   }
 }

--- a/basic-vite-react/package.json
+++ b/basic-vite-react/package.json
@@ -18,11 +18,11 @@
   "devDependencies": {
     "@types/react": "^18.2.33",
     "@types/react-dom": "^18.2.11",
-    "@vitejs/plugin-react": "^4.3.4",
+    "@vitejs/plugin-react": "^6.0.3",
     "globals": "^15.15.0",
     "tailwindcss": "^3.4.1",
     "autoprefixer": "^10.4.18",
     "typescript": "~5.7.2",
-    "vite": "^6.2.0"
+    "vite": "^8.1.4"
   }
 }

--- a/popular-package/package.json
+++ b/popular-package/package.json
@@ -25,7 +25,7 @@
     "@types/react": "^18.3.20",
     "@types/react-dom": "^18.3.5",
     "@types/three": "^0.174.0",
-    "@vitejs/plugin-react": "^4.3.4",
+    "@vitejs/plugin-react": "^6.0.3",
     "autoprefixer": "^10.4.21",
     "eslint": "^9.23.0",
     "eslint-plugin-react-hooks": "^5.2.0",
@@ -34,6 +34,6 @@
     "tailwindcss": "^3.4.17",
     "typescript": "~5.8.2",
     "typescript-eslint": "^8.28.0",
-    "vite": "^6.2.3"
+    "vite": "^8.1.4"
   }
 }


### PR DESCRIPTION
## 배경

프로덕션 memory_spike_log에서 남은 스파이크 원인이 **vite 퍼블리시 빌드 하나로 수렴**했습니다(4GB 머신에서 피크 1.4~1.9GB). config 레버는 실측 상한이 ~10%라, 구조적 레버는 vite 8의 Rolldown(Rust 번들러) 전환뿐입니다.

## 변경

17개 템플릿 + popular-package(컨테이너 사전 설치 시드) 전부:
- `vite`: ^6.x → **^8.1.4**
- `@vitejs/plugin-react`: ^4.x → **^6.0.3**

## 스테이징 컨테이너 실측 (동일 머신·동일 의존성·동일 소스, vite만 교체)

| | vite 6.4.3 (rollup) | vite 8.1.4 (rolldown) |
|---|---|---|
| 빌드 시간 | 20.6~22.8s | **2.7~3.2s (−87%)** |
| 피크 RSS | 1,294~1,464MB | **687~718MB (−50%)** |

## 검증

- [x] 17개 템플릿의 **11개 유니크 의존성 프로필 전부** vite 8.1.4로 빌드 성공 (9개 대표 + 아래 2개)
- [x] **런타임 검증 2종**: basic-3d-freeview(three+fiber+drei+rapier — 캐릭터·물리·그림자·UI 정상), 2d-phaser-basic — v6 빌드와 렌더링·콘솔 출력 동일
- [x] 설치 충돌 없음 (peer 깨끗)

## 영향 범위

- **신규 프로젝트부터 적용.** 기존 유저 프로젝트는 자기 package.json의 ^6.x 핀 때문에 bun update로도 6에 머묾 — 영향 없음
- 머지 후 컨테이너 이미지 재배포 시 사전 설치 node_modules에 vite 8이 들어감 (Containerfile이 빌드 타임에 이 저장소를 클론·병합). 재배포 전까지 신규 프로젝트는 퍼블리시 첫 회에 vite 8을 새로 다운로드(약간 느림)
- 산출물 차이: 청킹·minifier(Oxc)가 다르지만 위 런타임 검증으로 동작 동일 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 추가 실측: basic-3d-minecraft (실제 템플릿, 스테이징 컨테이너)

합성 fixture가 아닌 이 PR의 실제 템플릿으로도 동일 방법론(동일 머신, vite만 교체, VmHWM 폴링) 검증:

| | vite 6.4.3 | vite 8.1.4 (rolldown) |
|---|---|---|
| 빌드 시간 | 10.9~12.3s | **2.3~2.5s (−79%)** |
| 피크 RSS | 870~897MB | **629~649MB (−28%)** |
| dist | 3.6M | 3.5M |

메모리 감소율은 프로젝트 구성에 따라 −28%(중형 템플릿)~−50%(의존성 무거운 대형) 범위 — v8은 ~630MB 부근에 기본 바닥이 있고, 의존성 그래프가 클수록(=v6에서 메모리를 많이 먹던 프로젝트일수록) 감소폭이 커집니다. 프로덕션 스파이크를 만들던 1.4~1.9GB급 유저 프로젝트는 대형 쪽에 가깝습니다. 속도 이득(5~8배)은 프로젝트 크기와 무관하게 일관됩니다.