### PR TITLE
chore: raise chunkSizeWarningLimit to 5MB in all template vite configs

### DIFF
--- a/2d-phaser-basic/vite.config.ts
+++ b/2d-phaser-basic/vite.config.ts
@@ -13,5 +13,9 @@ export default defineConfig({
     // Skip gzip-size reporting: our users don't optimize by bundle size,
     // and it only slows the build. Output is byte-identical.
     reportCompressedSize: false,
+    // Game bundles (three/phaser) legitimately ship 1-3MB single chunks, so
+    // the default 500 kB advisory fires on every build as noise. Keep the
+    // warning only for genuinely pathological (5MB+) chunks.
+    chunkSizeWarningLimit: 5000,
   },
 });

--- a/2d-phaser-sprite-character-gravity/vite.config.ts
+++ b/2d-phaser-sprite-character-gravity/vite.config.ts
@@ -13,5 +13,9 @@ export default defineConfig({
     // Skip gzip-size reporting: our users don't optimize by bundle size,
     // and it only slows the build. Output is byte-identical.
     reportCompressedSize: false,
+    // Game bundles (three/phaser) legitimately ship 1-3MB single chunks, so
+    // the default 500 kB advisory fires on every build as noise. Keep the
+    // warning only for genuinely pathological (5MB+) chunks.
+    chunkSizeWarningLimit: 5000,
   },
 });

--- a/basic-2d/vite.config.ts
+++ b/basic-2d/vite.config.ts
@@ -13,5 +13,9 @@ export default defineConfig({
     // Skip gzip-size reporting: our users don't optimize by bundle size,
     // and it only slows the build. Output is byte-identical.
     reportCompressedSize: false,
+    // Game bundles (three/phaser) legitimately ship 1-3MB single chunks, so
+    // the default 500 kB advisory fires on every build as noise. Keep the
+    // warning only for genuinely pathological (5MB+) chunks.
+    chunkSizeWarningLimit: 5000,
   },
 });

--- a/basic-3d-firstpersonview-multiplay/vite.config.ts
+++ b/basic-3d-firstpersonview-multiplay/vite.config.ts
@@ -13,5 +13,9 @@ export default defineConfig({
     // Skip gzip-size reporting: our users don't optimize by bundle size,
     // and it only slows the build. Output is byte-identical.
     reportCompressedSize: false,
+    // Game bundles (three/phaser) legitimately ship 1-3MB single chunks, so
+    // the default 500 kB advisory fires on every build as noise. Keep the
+    // warning only for genuinely pathological (5MB+) chunks.
+    chunkSizeWarningLimit: 5000,
   },
 });

--- a/basic-3d-firstpersonview/vite.config.ts
+++ b/basic-3d-firstpersonview/vite.config.ts
@@ -13,5 +13,9 @@ export default defineConfig({
     // Skip gzip-size reporting: our users don't optimize by bundle size,
     // and it only slows the build. Output is byte-identical.
     reportCompressedSize: false,
+    // Game bundles (three/phaser) legitimately ship 1-3MB single chunks, so
+    // the default 500 kB advisory fires on every build as noise. Keep the
+    // warning only for genuinely pathological (5MB+) chunks.
+    chunkSizeWarningLimit: 5000,
   },
 });

--- a/basic-3d-flightview-multiplay/vite.config.ts
+++ b/basic-3d-flightview-multiplay/vite.config.ts
@@ -13,5 +13,9 @@ export default defineConfig({
     // Skip gzip-size reporting: our users don't optimize by bundle size,
     // and it only slows the build. Output is byte-identical.
     reportCompressedSize: false,
+    // Game bundles (three/phaser) legitimately ship 1-3MB single chunks, so
+    // the default 500 kB advisory fires on every build as noise. Keep the
+    // warning only for genuinely pathological (5MB+) chunks.
+    chunkSizeWarningLimit: 5000,
   },
 });

--- a/basic-3d-flightview/vite.config.ts
+++ b/basic-3d-flightview/vite.config.ts
@@ -13,5 +13,9 @@ export default defineConfig({
     // Skip gzip-size reporting: our users don't optimize by bundle size,
     // and it only slows the build. Output is byte-identical.
     reportCompressedSize: false,
+    // Game bundles (three/phaser) legitimately ship 1-3MB single chunks, so
+    // the default 500 kB advisory fires on every build as noise. Keep the
+    // warning only for genuinely pathological (5MB+) chunks.
+    chunkSizeWarningLimit: 5000,
   },
 });

--- a/basic-3d-freeview-multiplay/vite.config.ts
+++ b/basic-3d-freeview-multiplay/vite.config.ts
@@ -13,5 +13,9 @@ export default defineConfig({
     // Skip gzip-size reporting: our users don't optimize by bundle size,
     // and it only slows the build. Output is byte-identical.
     reportCompressedSize: false,
+    // Game bundles (three/phaser) legitimately ship 1-3MB single chunks, so
+    // the default 500 kB advisory fires on every build as noise. Keep the
+    // warning only for genuinely pathological (5MB+) chunks.
+    chunkSizeWarningLimit: 5000,
   },
 });

--- a/basic-3d-freeview/vite.config.ts
+++ b/basic-3d-freeview/vite.config.ts
@@ -13,5 +13,9 @@ export default defineConfig({
     // Skip gzip-size reporting: our users don't optimize by bundle size,
     // and it only slows the build. Output is byte-identical.
     reportCompressedSize: false,
+    // Game bundles (three/phaser) legitimately ship 1-3MB single chunks, so
+    // the default 500 kB advisory fires on every build as noise. Keep the
+    // warning only for genuinely pathological (5MB+) chunks.
+    chunkSizeWarningLimit: 5000,
   },
 });

--- a/basic-3d-minecraft-multiplay/vite.config.ts
+++ b/basic-3d-minecraft-multiplay/vite.config.ts
@@ -13,5 +13,9 @@ export default defineConfig({
     // Skip gzip-size reporting: our users don't optimize by bundle size,
     // and it only slows the build. Output is byte-identical.
     reportCompressedSize: false,
+    // Game bundles (three/phaser) legitimately ship 1-3MB single chunks, so
+    // the default 500 kB advisory fires on every build as noise. Keep the
+    // warning only for genuinely pathological (5MB+) chunks.
+    chunkSizeWarningLimit: 5000,
   },
 });

--- a/basic-3d-minecraft/vite.config.ts
+++ b/basic-3d-minecraft/vite.config.ts
@@ -13,5 +13,9 @@ export default defineConfig({
     // Skip gzip-size reporting: our users don't optimize by bundle size,
     // and it only slows the build. Output is byte-identical.
     reportCompressedSize: false,
+    // Game bundles (three/phaser) legitimately ship 1-3MB single chunks, so
+    // the default 500 kB advisory fires on every build as noise. Keep the
+    // warning only for genuinely pathological (5MB+) chunks.
+    chunkSizeWarningLimit: 5000,
   },
 });

--- a/basic-3d-quarterview-multiplay/vite.config.ts
+++ b/basic-3d-quarterview-multiplay/vite.config.ts
@@ -13,5 +13,9 @@ export default defineConfig({
     // Skip gzip-size reporting: our users don't optimize by bundle size,
     // and it only slows the build. Output is byte-identical.
     reportCompressedSize: false,
+    // Game bundles (three/phaser) legitimately ship 1-3MB single chunks, so
+    // the default 500 kB advisory fires on every build as noise. Keep the
+    // warning only for genuinely pathological (5MB+) chunks.
+    chunkSizeWarningLimit: 5000,
   },
 });

--- a/basic-3d-quarterview/vite.config.ts
+++ b/basic-3d-quarterview/vite.config.ts
@@ -13,5 +13,9 @@ export default defineConfig({
     // Skip gzip-size reporting: our users don't optimize by bundle size,
     // and it only slows the build. Output is byte-identical.
     reportCompressedSize: false,
+    // Game bundles (three/phaser) legitimately ship 1-3MB single chunks, so
+    // the default 500 kB advisory fires on every build as noise. Keep the
+    // warning only for genuinely pathological (5MB+) chunks.
+    chunkSizeWarningLimit: 5000,
   },
 });

--- a/basic-3d-sideview-multiplay/vite.config.ts
+++ b/basic-3d-sideview-multiplay/vite.config.ts
@@ -13,5 +13,9 @@ export default defineConfig({
     // Skip gzip-size reporting: our users don't optimize by bundle size,
     // and it only slows the build. Output is byte-identical.
     reportCompressedSize: false,
+    // Game bundles (three/phaser) legitimately ship 1-3MB single chunks, so
+    // the default 500 kB advisory fires on every build as noise. Keep the
+    // warning only for genuinely pathological (5MB+) chunks.
+    chunkSizeWarningLimit: 5000,
   },
 });

--- a/basic-3d-sideview/vite.config.ts
+++ b/basic-3d-sideview/vite.config.ts
@@ -13,5 +13,9 @@ export default defineConfig({
     // Skip gzip-size reporting: our users don't optimize by bundle size,
     // and it only slows the build. Output is byte-identical.
     reportCompressedSize: false,
+    // Game bundles (three/phaser) legitimately ship 1-3MB single chunks, so
+    // the default 500 kB advisory fires on every build as noise. Keep the
+    // warning only for genuinely pathological (5MB+) chunks.
+    chunkSizeWarningLimit: 5000,
   },
 });

--- a/basic-3d/vite.config.ts
+++ b/basic-3d/vite.config.ts
@@ -13,5 +13,9 @@ export default defineConfig({
     // Skip gzip-size reporting: our users don't optimize by bundle size,
     // and it only slows the build. Output is byte-identical.
     reportCompressedSize: false,
+    // Game bundles (three/phaser) legitimately ship 1-3MB single chunks, so
+    // the default 500 kB advisory fires on every build as noise. Keep the
+    // warning only for genuinely pathological (5MB+) chunks.
+    chunkSizeWarningLimit: 5000,
   },
 });

--- a/basic-vite-react/vite.config.ts
+++ b/basic-vite-react/vite.config.ts
@@ -13,5 +13,9 @@ export default defineConfig({
     // Skip gzip-size reporting: our users don't optimize by bundle size,
     // and it only slows the build. Output is byte-identical.
     reportCompressedSize: false,
+    // Game bundles (three/phaser) legitimately ship 1-3MB single chunks, so
+    // the default 500 kB advisory fires on every build as noise. Keep the
+    // warning only for genuinely pathological (5MB+) chunks.
+    chunkSizeWarningLimit: 5000,
   },
 });


### PR DESCRIPTION
## 배경

게임 프로젝트는 three/phaser 때문에 단일 JS 청크 1~3MB가 정상이라, vite 기본값(500kB)의 `(!) Some chunks are larger than 500 kB` 노란 경고가 **모든 빌드마다** 출력됩니다. 바이브코딩 사용자에게는 실행 불가능한 권고 = 순수 노이즈입니다.

## 변경

17개 템플릿 build 블록에 `chunkSizeWarningLimit: 5000` 추가 — 진짜 병적인(5MB+) 청크만 경고 유지.

## 성격

- **완전히 코스메틱**: 이 값은 경고 출력 기준선일 뿐, 청크 크기는 원래 어떤 값이든 허용됨. 산출물 무변화.
- 변경 후 17개 config 해시 동일 + 전부 esbuild 트랜스파일 통과.
- 내장 템플릿(container-agent template.ts) 동기화 PR 별도 (지난 #85 때 빼먹었던 것 방지).

🤖 Generated with [Claude Code](https://claude.com/claude-code)